### PR TITLE
Better csrf_token handling

### DIFF
--- a/plugins/dynamix/include/CSRFToken.php
+++ b/plugins/dynamix/include/CSRFToken.php
@@ -1,0 +1,21 @@
+<?PHP
+/* Copyright 2005-2016, Lime Technology
+ * Copyright 2012-2016, Bergware International.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+?>
+<?
+#load emhttp variables if needed.
+$docroot = $docroot ?: @$_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
+if (!isset($var)) {
+  if (!is_file("$docroot/state/var.ini")) shell_exec("wget -qO /dev/null localhost:$(lsof -nPc emhttp | grep -Po 'TCP[^\d]*\K\d+')");
+  $var = @parse_ini_file("$docroot/state/var.ini");
+}
+echo $var['csrf_token'];
+?>

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -278,14 +278,41 @@ $(function() {
 });
 var mobiles=['ipad','iphone','ipod','android'];
 var device=navigator.platform.toLowerCase();
+var csrf_token = "<?=$var['csrf_token']?>";
 for (var i=0,mobile; mobile=mobiles[i]; i++) {
   if (device.indexOf(mobile)>=0) {$('#footer').css('position','static'); break;}
 }
-$(document).ajaxSend(function(elm, xhr, s){
-  if (s.type == "POST") {
-    s.data += s.data?"&":"";
-    s.data += "csrf_token=<?=$var['csrf_token']?>";
+$.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
+  // Allow just one retry
+  originalOptions._error = originalOptions.error;
+  if (typeof(originalOptions._retry) === "undefined" ) {
+    originalOptions._retry = true;
   }
+
+  // Inject csrf_token into POST data
+  var data = originalOptions.data;
+  if (originalOptions.type == "post" && originalOptions.data !== undefined) {
+    if (Object.prototype.toString.call(originalOptions.data) === '[object String]') {
+      data = $.deparam(originalOptions.data);
+    }
+  } else {
+    data = {};
+  }
+  options.data = $.param($.extend(data, { csrf_token: csrf_token }));
+
+  options.error = function( _jqXHR, _textStatus, _errorThrown ) {
+    if (_jqXHR.status == "403" && originalOptions._retry) {
+      $.get("/webGui/include/CSRFToken.php", function(token)
+      {
+        csrf_token = token;
+        originalOptions._retry = false;
+        $.ajax( originalOptions );
+      });
+    } else {
+      if( originalOptions._error ) originalOptions._error( _jqXHR, _textStatus, _errorThrown );
+      return;
+    }
+  };
 });
 </script>
 </head>


### PR DESCRIPTION
This is a drop-in replacement for the ajaxSend() function. It will inject the csrf_token in every POST request done using ajax, and, if a status 403 is received from the server, it will retrieve the current csrf_token from the server and retry the request once.

This will require emhttp to trow a 403 error when csrf_token is wrong or missing.