### PR TITLE
Remove the old temp .plg file on remove

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -485,6 +485,7 @@ if ($method == "remove") {
   if ($installed_plugin_file !== false) {
     // remove the symlink
     unlink("/var/log/plugins/$plugin");
+    @unlink("/tmp/plugins/$plugin");
     if (plugin("remove", $installed_plugin_file, $error) === false) {
       // but if can't remove, restore the symlink
       symlink($installed_plugin_file, "/var/log/plugins/$plugin");


### PR DESCRIPTION
plugincheck script doesn't check if a plugin is still installed.  Only if the .plg still exists in /tmp/plugins.  Update notices will happen until a reboot is issued