### PR TITLE
Allow referrals from CA to dockerMan to return to CA when pressing Done

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1726,5 +1726,10 @@ $showAdditionalInfo = '';
     }?>
   });
 </script>
-<?END:?>
+<?END:
+if ($_GET['caRefer']):
+?>
+<div id='caRefer' style='display:none'></div>
+<?endif;?>
+
 

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -126,6 +126,13 @@ function done(key) {
   var path = '/'+url[1];
   if (key) for (var i=2; i<url.length; i++) if (url[i]==key) break; else path += '/'+url[i];
   $.removeCookie('one',{path:'/'});
+  if ( $("#caRefer").length) {
+    $("input").each(function() {
+      if ( $(this).val() == "Done" ) {
+        path = "/Apps";
+      }
+    });
+  }
   location.replace(path);
 }
 function chkDelete(form, button) {


### PR DESCRIPTION
Currently, if a CA user presses Done after installing / editing a container, upon pressing Done they will be taken to a blank Add Template Page.
It is far neater to instead have them taken back to the Apps tab instead.