### PR TITLE
Update plugins without page refresh

### DIFF
--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -40,7 +40,8 @@ function openBox2(cmd,title,height,width,load) {
   var options = load ? {modal:true,onClose:function(){    
       $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){
         if (data && document.getElementById(plugin)) {
-          document.getElementById(plugin).outerHTML=data;      
+          document.getElementById(plugin).innerHTML=data;
+          $('.desc_readmore').readmore({maxHeight:58});          
         } else {
           // an error occurred or plugin was removed. reload the page
           location=location;

--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -36,6 +36,7 @@ function openBox2(cmd,title,height,width,load) {
   // customized version of openBox specifically for dynamix.plugin.manager
   // open shadowbox window (run in foreground)
   var run = cmd.split('?')[0].substr(-4)=='.php' ? cmd : '/logging.htm?cmd='+cmd+'&csrf_token=<?=$var['csrf_token']?>';
+  var plugin=getParameterByNameFromUrl("arg2",cmd);
   var options = load ? {modal:true,onClose:function(){    
       $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){
         if (data && document.getElementById(plugin)) {

--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -28,6 +28,20 @@ $audit = $notify['version'] ? 1 : 0;
 </style>
 <script src="/webGui/javascript/jquery.filetree.js"></script>
 <script>
+function getParameterByNameFromUrl(name, url) {
+  var match = RegExp('[?&]' + name + '=([^&]*)').exec(url);
+  return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+}
+function openBox2(cmd,title,height,width,load) {
+  // customized version of openBox specifically for dynamix.plugin.manager
+  // open shadowbox window (run in foreground)
+  var run = cmd.split('?')[0].substr(-4)=='.php' ? cmd : '/logging.htm?cmd='+cmd+'&csrf_token=<?=$var['csrf_token']?>';
+  var plugin=getParameterByNameFromUrl("arg2",cmd);  
+  var options = load ? {modal:true,onClose:function(){    
+    $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){document.getElementById(plugin).outerHTML=data;} )
+    }} : {modal:true};
+  Shadowbox.open({content:run, player:'iframe', title:title, height:height, width:width, options:options});
+}
 <?if ($display['resize']):?>
 function resize(bind) {
   var width = [];

--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -40,8 +40,9 @@ function openBox2(cmd,title,height,width,load) {
   var options = load ? {modal:true,onClose:function(){    
       $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){
         if (data && document.getElementById(plugin)) {
-          document.getElementById(plugin).innerHTML=data;
-          $('.desc_readmore').readmore({maxHeight:58});          
+          document.getElementById(plugin).outerHTML=data;
+          $('.desc_readmore').readmore({maxHeight:58});
+          $('#plugin_table').trigger("update");          
         } else {
           // an error occurred or plugin was removed. reload the page
           location=location;

--- a/plugins/dynamix.plugin.manager/Plugins.page
+++ b/plugins/dynamix.plugin.manager/Plugins.page
@@ -36,9 +36,15 @@ function openBox2(cmd,title,height,width,load) {
   // customized version of openBox specifically for dynamix.plugin.manager
   // open shadowbox window (run in foreground)
   var run = cmd.split('?')[0].substr(-4)=='.php' ? cmd : '/logging.htm?cmd='+cmd+'&csrf_token=<?=$var['csrf_token']?>';
-  var plugin=getParameterByNameFromUrl("arg2",cmd);  
   var options = load ? {modal:true,onClose:function(){    
-    $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){document.getElementById(plugin).outerHTML=data;} )
+      $.get('/plugins/dynamix.plugin.manager/include/ShowPluginRow.php', {plugin:plugin}, function(data){
+        if (data && document.getElementById(plugin)) {
+          document.getElementById(plugin).outerHTML=data;      
+        } else {
+          // an error occurred or plugin was removed. reload the page
+          location=location;
+        }
+      } )
     }} : {modal:true};
   Shadowbox.open({content:run, player:'iframe', title:title, height:height, width:width, options:options});
 }

--- a/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -32,7 +32,7 @@ function make_link($method, $arg, $extra='') {
   $disabled = $check ? ' disabled' : '';
   $cmd = $method == 'delete' ? "/plugins/dynamix.plugin.manager/scripts/plugin_rm&arg1=$arg" : "/plugins/dynamix.plugin.manager/scripts/plugin&arg1=$method&arg2=$arg".($extra?"&arg3=$extra":"");
   $clr = $method == 'delete' ? "" : "noAudit();";
-  return "{$check}<input type='button' id='$id' value='".ucfirst($method)."' onclick='{$clr}openBox(\"{$cmd}\",\"".ucwords($method)." Plugin\",600,900,true)'{$disabled}>";
+  return "{$check}<input type='button' id='$id' value='".ucfirst($method)."' onclick='{$clr}openBox2(\"{$cmd}\",\"".ucwords($method)." Plugin\",600,900,true)'{$disabled}>";
 }
 
 // trying our best to find an icon
@@ -55,5 +55,106 @@ function icon($name) {
 }
 function mk_options($select,$value) {
   return "<option value='$value'".($select==$value?" selected":"").">".ucfirst($value)."</option>";
+}
+
+function make_row($plugin_file) {
+  global $system, $branch, $audit, $empty, $builtin, $https;
+  
+//plugin name
+  $name = plugin('name',$plugin_file) ?: basename($plugin_file,".plg");
+  $custom = in_array($name,$builtin);
+//switch between system and custom plugins
+  if (($system && !$custom) || (!$system && $custom)) return;
+//forced plugin check?
+  $checked = $audit ? check_plugin(basename($plugin_file)) : true;
+//OS update?
+  $os = $system && $name==$builtin[0];
+  $toggle = false;
+//toggle stable/next release?
+  if ($os && $branch) {
+    $toggle = plugin('version',$plugin_file);
+    $cat = strpos($toggle,'rc')!==false ? 'stable' : 'next';
+    $tmp_plg = "$name-.plg";
+    $tmp_file = "/var/tmp/$name.plg";
+    copy($plugin_file,$tmp_file);
+    exec("sed -ri 's|^(<!ENTITY category).*|\\1 \"{$cat}\">|' $tmp_file");
+    exec("sed -ri 's|^(<!ENTITY pluginURL).*|\\1 \"{$https[$branch]}\">|' $tmp_file");
+    symlink($tmp_file,"/var/log/plugins/$tmp_plg");
+    if (check_plugin($tmp_plg)) {
+      copy("/tmp/plugins/$tmp_plg",$tmp_file);
+      $plugin_file = $tmp_file;
+    }
+  }
+//link/icon
+  $icon = icon($name);
+  if ($launch = plugin('launch',$plugin_file))
+    $link = "<a href='/$launch'><img src='/$icon' class='list'></a>";
+  else
+    $link = "<img src='/$icon' class='list'>";
+//description
+  $readme = "plugins/{$name}/README.md";
+  if (file_exists($readme))
+    $desc = Markdown(file_get_contents($readme));
+  else
+    $desc = Markdown("**{$name}**");
+//author
+  $author = plugin('author',$plugin_file) ?: "anonymous";
+//version
+  $version = plugin('version',$plugin_file) ?: "unknown";
+//category
+  $cat = strpos($version,'rc')!==false ? 'next' : 'stable';
+//status
+  $status = 'unknown';
+  $changes_file = $plugin_file;
+  $url = plugin('pluginURL',$plugin_file);
+  if ($url !== false) {
+    $filename = "/tmp/plugins/".(($os && $branch) ? $tmp_plg : basename($url));
+    if ($checked && file_exists($filename)) {
+      if ($toggle && $toggle != $version) {
+        $status = make_link('install',$plugin_file,'forced');
+      } else {
+        $latest = plugin('version',$filename);
+        #if (strcmp($latest,$version) > 0) {
+        if (strcmp($latest,$version) > $fake) {
+          $version .= "<br><span class='red-text'>{$latest}</span>";
+          $status = make_link("update",basename($plugin_file));
+          $changes_file = $filename;
+        } else {
+          //status is considered outdated when older than 1 day
+          $status = filectime($filename) > (time()-86400) ? 'up-to-date' : 'need check';
+        }
+      }
+    }
+  }
+  $changes = plugin('changes',$changes_file);
+  if ($changes !== false) {
+    $txtfile = "/tmp/plugins/".basename($plugin_file,'.plg').".txt";
+    file_put_contents($txtfile,$changes);
+    $version .= "&nbsp;<a href='#' title='View Release Notes' onclick=\"openBox('/plugins/dynamix.plugin.manager/include/ShowChanges.php?file=".urlencode($txtfile)."','Release Notes',600,900); return false\"><img src='/webGui/images/information.png' class='icon'></a>";
+  }
+//write plugin information
+  $empty = false;
+  echo "<tr id='".basename($plugin_file)."'>";
+  echo "<td style='vertical-align:top;width:64px'><p style='text-align:center'>{$link}</p></td>";
+  echo "<td><span class='desc_readmore' style='display:block'>{$desc}</span></td>";
+  echo "<td>{$author}</td>";
+  echo "<td>{$version}</td>";
+  echo "<td>{$status}</td>";
+  echo "<td>";
+  if ($system) {
+    if ($os) {
+      echo "<select id='change_branch' class='auto' onchange='update_table(this.value)'>";
+      echo mk_options($cat,'stable');
+      echo mk_options($cat,'next');
+      echo "</select>";
+    }
+  } else {
+    echo make_link('remove',basename($plugin_file));
+  }
+  echo "</td>";
+  echo "</tr>";
+//remove temporary symlink
+  @unlink("/var/log/plugins/$tmp_plg");
+
 }
 ?>

--- a/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -57,7 +57,7 @@ function mk_options($select,$value) {
   return "<option value='$value'".($select==$value?" selected":"").">".ucfirst($value)."</option>";
 }
 
-function make_row($plugin_file) {
+function make_row($plugin_file, $show_tr) {
   global $system, $branch, $audit, $empty, $builtin, $https;
   
 //plugin name
@@ -133,7 +133,7 @@ function make_row($plugin_file) {
   }
 //write plugin information
   $empty = false;
-  echo "<tr id='".basename($plugin_file)."'>";
+  if ($show_tr) echo "<tr id='".basename($plugin_file)."'>";
   echo "<td style='vertical-align:top;width:64px'><p style='text-align:center'>{$link}</p></td>";
   echo "<td><span class='desc_readmore' style='display:block'>{$desc}</span></td>";
   echo "<td>{$author}</td>";
@@ -151,7 +151,7 @@ function make_row($plugin_file) {
     echo make_link('remove',basename($plugin_file));
   }
   echo "</td>";
-  echo "</tr>";
+  if ($show_tr) echo "</tr>\n\n";
 //remove temporary symlink
   @unlink("/var/log/plugins/$tmp_plg");
 

--- a/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -114,8 +114,7 @@ function make_row($plugin_file) {
         $status = make_link('install',$plugin_file,'forced');
       } else {
         $latest = plugin('version',$filename);
-        #if (strcmp($latest,$version) > 0) {
-        if (strcmp($latest,$version) > $fake) {
+        if (strcmp($latest,$version) > 0) {
           $version .= "<br><span class='red-text'>{$latest}</span>";
           $status = make_link("update",basename($plugin_file));
           $changes_file = $filename;

--- a/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -57,7 +57,7 @@ function mk_options($select,$value) {
   return "<option value='$value'".($select==$value?" selected":"").">".ucfirst($value)."</option>";
 }
 
-function make_row($plugin_file, $show_tr) {
+function make_row($plugin_file) {
   global $system, $branch, $audit, $empty, $builtin, $https;
   
 //plugin name
@@ -133,7 +133,7 @@ function make_row($plugin_file, $show_tr) {
   }
 //write plugin information
   $empty = false;
-  if ($show_tr) echo "<tr id='".basename($plugin_file)."'>";
+  echo "<tr id='".basename($plugin_file)."'>";
   echo "<td style='vertical-align:top;width:64px'><p style='text-align:center'>{$link}</p></td>";
   echo "<td><span class='desc_readmore' style='display:block'>{$desc}</span></td>";
   echo "<td>{$author}</td>";
@@ -151,7 +151,7 @@ function make_row($plugin_file, $show_tr) {
     echo make_link('remove',basename($plugin_file));
   }
   echo "</td>";
-  if ($show_tr) echo "</tr>\n\n";
+  echo "</tr>\n\n";
 //remove temporary symlink
   @unlink("/var/log/plugins/$tmp_plg");
 

--- a/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
@@ -28,7 +28,7 @@ $plugin   = $_GET['plugin'] ?? false;
 if ($plugin) {
   //only consider symlinks
   $plugin_file = @readlink("/var/log/plugins/".$plugin);
-  if ($plugin_file !== false) make_row($plugin_file);
+  if ($plugin_file !== false) make_row($plugin_file, false);
 }
 if ($empty) echo ""; // i.e. do nothing
 ?>

--- a/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
@@ -21,13 +21,14 @@ $audit   = $_GET['audit'] ?? false;
 $empty   = true;
 $builtin = ['unRAIDServer'];
 $https   = ['stable' => 'https://raw.github.com/limetech/\&name;/master/\&name;.plg',
-            'next'   => 'https://s3.amazonaws.com/dnld.lime-technology.com/\&category;/\&name;.plg'];
+    'next'   => 'https://s3.amazonaws.com/dnld.lime-technology.com/\&category;/\&name;.plg'];
 
-foreach (glob("/var/log/plugins/*.plg",GLOB_NOSORT) as $plugin_link) {
-//only consider symlinks
-  $plugin_file = @readlink($plugin_link);
-  if ($plugin_file === false) continue;
-  make_row($plugin_file);
+$plugin   = $_GET['plugin'] ?? false;
+
+if ($plugin) {
+  //only consider symlinks
+  $plugin_file = @readlink("/var/log/plugins/".$plugin);
+  if ($plugin_file !== false) make_row($plugin_file);
 }
 if ($empty) echo "<tr><td colspan='6' style='text-align:center;padding-top:12px'><i class='fa fa-check-square-o icon'></i> No plugins installed</td><tr>";
 ?>

--- a/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
@@ -30,5 +30,5 @@ if ($plugin) {
   $plugin_file = @readlink("/var/log/plugins/".$plugin);
   if ($plugin_file !== false) make_row($plugin_file);
 }
-if ($empty) echo "<tr><td colspan='6' style='text-align:center;padding-top:12px'><i class='fa fa-check-square-o icon'></i> No plugins installed</td><tr>";
+if ($empty) echo ""; // i.e. do nothing
 ?>

--- a/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPluginRow.php
@@ -28,7 +28,7 @@ $plugin   = $_GET['plugin'] ?? false;
 if ($plugin) {
   //only consider symlinks
   $plugin_file = @readlink("/var/log/plugins/".$plugin);
-  if ($plugin_file !== false) make_row($plugin_file, false);
+  if ($plugin_file !== false) make_row($plugin_file);
 }
 if ($empty) echo ""; // i.e. do nothing
 ?>

--- a/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -26,8 +26,7 @@ $https   = ['stable' => 'https://raw.github.com/limetech/\&name;/master/\&name;.
 foreach (glob("/var/log/plugins/*.plg",GLOB_NOSORT) as $plugin_link) {
 //only consider symlinks
   $plugin_file = @readlink($plugin_link);
-  if ($plugin_file === false) continue;
-  make_row($plugin_file, true);
+  if ($plugin_file !== false) make_row($plugin_file);
 }
 if ($empty) echo "<tr><td colspan='6' style='text-align:center;padding-top:12px'><i class='fa fa-check-square-o icon'></i> No plugins installed</td><tr>";
 ?>

--- a/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -27,7 +27,7 @@ foreach (glob("/var/log/plugins/*.plg",GLOB_NOSORT) as $plugin_link) {
 //only consider symlinks
   $plugin_file = @readlink($plugin_link);
   if ($plugin_file === false) continue;
-  make_row($plugin_file);
+  make_row($plugin_file, true);
 }
 if ($empty) echo "<tr><td colspan='6' style='text-align:center;padding-top:12px'><i class='fa fa-check-square-o icon'></i> No plugins installed</td><tr>";
 ?>


### PR DESCRIPTION
After updating a plugin, display latest plugin information inline, rather than requiring a full page refresh.