### PR TITLE
Addition of Error Correction Type information

### DIFF
--- a/plugins/dynamix/include/SystemInformation.php
+++ b/plugins/dynamix/include/SystemInformation.php
@@ -142,8 +142,8 @@ $memory_installed = exec("dmidecode -t 17 | awk -F: '/^\tSize: [0-9]+ MB$/{t+=$2
 // Extract error correction type, if none, do not include additional information in the output
 list($memory_maximum, $ecc_support) = array_map("trim", explode("#", exec("dmidecode -t16|awk -F: '/^\tMaximum Capacity: [0-9]+ GB$/{t+=$2};/^\tError Correction Type:/{e=$2} END{print t\"#\"e}'")));
 // If maximum < installed then roundup maximum to the next power of 2 size of installed. E.g. 6 -> 8 or 12 -> 16
-if ($memory_maximum < $memory_installed) {$memory_maximum = pow(2,ceil(log($memory_installed)/log(2))); $star = "*";}
 $star = "";
+if ($memory_maximum < $memory_installed) {$memory_maximum = pow(2,ceil(log($memory_installed)/log(2))); $star = "*";}
 echo "$memory_installed GB ".($ecc_support == "None" ? "" : "$ecc_support ")."(max. installable capacity $memory_maximum GB)$star";
 ?>
 </div>

--- a/plugins/dynamix/include/SystemInformation.php
+++ b/plugins/dynamix/include/SystemInformation.php
@@ -139,15 +139,12 @@ $memory_installed = exec("dmidecode -t 17 | awk -F: '/^\tSize: [0-9]+ MB$/{t+=$2
 // Physical Memory Array (16) usually one of these for a desktop-class motherboard but higher-end xeon motherboards
 // might have two or more of these.  The trick is to filter out any Flash/Bios types by matching on GB
 // Sum up all the Physical Memory Arrays to get the motherboard's total memory capacity
-$memory_maximum = exec("dmidecode -t 16 | awk -F: '/^\tMaximum Capacity: [0-9]+ GB$/{t+=$2} END{print t}'");
-// Read the physical memory info again and extract the error correction type. If the type is "None", 
-// empty the correction type string, otherwise insert a whitespace at the end of it as a hacky separator.
-$ecc_support = exec("dmidecode -t 16 | awk -F': ' '/^\tError Correction Type: / {print $2}'");
-if($ecc_support == "None") $ecc_support = ""; else $ecc_support = $ecc_support." ";
-$star = "";
+// Extract error correction type, if none, do not include additional information in the output
+list($memory_maximum, $ecc_support) = array_map("trim", explode("#", exec("dmidecode -t16|awk -F: '/^\tMaximum Capacity: [0-9]+ GB$/{t+=$2};/^\tError Correction Type:/{e=$2} END{print t\"#\"e}'")));
 // If maximum < installed then roundup maximum to the next power of 2 size of installed. E.g. 6 -> 8 or 12 -> 16
 if ($memory_maximum < $memory_installed) {$memory_maximum = pow(2,ceil(log($memory_installed)/log(2))); $star = "*";}
-echo "$memory_installed GB $ecc_support(max. installable capacity $memory_maximum GB)$star";
+$star = "";
+echo "$memory_installed GB ".($ecc_support == "None" ? "" : "$ecc_support ")."(max. installable capacity $memory_maximum GB)$star";
 ?>
 </div>
 <div><span class="key">Network:</span>

--- a/plugins/dynamix/include/SystemInformation.php
+++ b/plugins/dynamix/include/SystemInformation.php
@@ -140,10 +140,14 @@ $memory_installed = exec("dmidecode -t 17 | awk -F: '/^\tSize: [0-9]+ MB$/{t+=$2
 // might have two or more of these.  The trick is to filter out any Flash/Bios types by matching on GB
 // Sum up all the Physical Memory Arrays to get the motherboard's total memory capacity
 $memory_maximum = exec("dmidecode -t 16 | awk -F: '/^\tMaximum Capacity: [0-9]+ GB$/{t+=$2} END{print t}'");
+// Read the physical memory info again and extract the error correction type. If the type is "None", 
+// empty the correction type string, otherwise insert a whitespace at the end of it as a hacky separator.
+$ecc_support = exec("dmidecode -t 16 | awk -F': ' '/^\tError Correction Type: / {print $2}'");
+if($ecc_support == "None") $ecc_support = ""; else $ecc_support = $ecc_support." ";
 $star = "";
 // If maximum < installed then roundup maximum to the next power of 2 size of installed. E.g. 6 -> 8 or 12 -> 16
 if ($memory_maximum < $memory_installed) {$memory_maximum = pow(2,ceil(log($memory_installed)/log(2))); $star = "*";}
-echo "$memory_installed GB (max. installable capacity $memory_maximum GB)$star";
+echo "$memory_installed GB $ecc_support(max. installable capacity $memory_maximum GB)$star";
 ?>
 </div>
 <div><span class="key">Network:</span>


### PR DESCRIPTION
It would be great to start integrating ECC/EDAC support in unRAID, one of the first steps might be to display relevant information from the BIOS/UEFI.

Reducing the `dmidecode -t 16` calls to one is preferable, I am not aware if `Maximum Capacity` and `Error Correction Type` can be extracted with `awk` in one go without having to `explode` the row as done with `$cache`, otherwise it would be fine.

[
<img width="438" alt="screen shot 2017-09-22 at 01 32 00" src="https://user-images.githubusercontent.com/5107843/30721708-03d9e470-9f36-11e7-80f6-c5ed15d50b55.png">
](url)