### PR TITLE
Prevent cron error entering syslog.

### DIFF
--- a/plugins/dynamix/include/update.parity.php
+++ b/plugins/dynamix/include/update.parity.php
@@ -50,7 +50,7 @@ if (isset($_POST['#apply'])) {
     $month = isset($_POST['month']) ? $_POST['month'] : '*';
     $day = isset($_POST['day']) ? $_POST['day'] : '*';
     $write = isset($_POST['write']) ? $_POST['write'] : '';
-    $cron = "# Generated parity check schedule:\n$time $dotm $month $day $term/usr/local/sbin/mdcmd check $write &> /dev/null\n\n";
+    $cron = "# Generated parity check schedule:\n$time $dotm $month $day $term/usr/local/sbin/mdcmd check $write &> /dev/null || :\n\n";
   }
   parse_cron_cfg("dynamix", "parity-check", $cron);
   @unlink($memory);


### PR DESCRIPTION
If parity check schedule is set to 1st week, 2nd week, etc a cron error is logged when when not on the selected week due to return value of 1 from the date check.  Return a value of zero instead.