### PR TITLE
Array status statistics panel space optimisation

### DIFF
--- a/plugins/dynamix/DashStats.page
+++ b/plugins/dynamix/DashStats.page
@@ -115,17 +115,17 @@ $slots = count($disks) + count($devs);
 ?>
 <?if ($slots<30):?>
 <style>
-table.share_status.fixed td:nth-child(<?=$slots+1?>)~td{visibility:hidden}
+table.share_status.fixed td:nth-child(<?=$slots+1?>)~td{display:none}
 </style>
 <?endif;?>
 <table class='share_status fixed'>
 <thead><tr>
 <?
 $row0 = array_fill(0,30,"<td>-</td>"); $i = 0;
-foreach ($disks as $disk) if ($disk['type']=='Parity') $row0[$i++] = "<td>Parity<br>&nbsp;".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."&nbsp;</td>";
-foreach ($disks as $disk) if ($disk['type']=='Data') $row0[$i++] = "<td>Disk<br>&nbsp;".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."&nbsp;</td>";
+foreach ($disks as $disk) if ($disk['type']=='Parity') $row0[$i++] = "<td>Parity".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."</td>";
+foreach ($disks as $disk) if ($disk['type']=='Data') $row0[$i++] = "<td>Disk ".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."</td>";
 if ($slots <= 30) {
-  foreach ($disks as $disk) if ($disk['type']=='Cache') $row0[$i++] = "<td>Cache<br>&nbsp;".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."&nbsp;</td>";
+  foreach ($disks as $disk) if ($disk['type']=='Cache') $row0[$i++] = "<td>Cache ".filter_var($disk['name'],FILTER_SANITIZE_NUMBER_INT)."</td>";
   foreach ($devs as $dev) $row0[$i++] = "<td>{$dev['device']}</td>";
 }
 echo "<td>Array Status</td>".implode('',$row0);


### PR DESCRIPTION
Using the available screen estate is always better than leaving unused space. Pre-filling the layout with disk columns that are not in use is unnecessary. This patch expands the columns of available system disks to the full width of the panel and is a step forward towards a responsive layout that scales with screen size.

Future iterations of this panel might benefit from rendering data of individual disks per row instead of per column, exponentially growing vertically instead of horizontally.

![unraid array status patch](https://user-images.githubusercontent.com/5107843/31416213-96ddf64c-ae1f-11e7-8b7f-a3a983ea1eba.png)