### PR TITLE
Add VM template for unRAID

### DIFF
--- a/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/classes/libvirt_helpers.php
@@ -253,6 +253,11 @@
 			'icon' => 'ubuntu.png',
 			'os' => 'ubuntu'
 		],
+		'unRAID' => [
+			'form' => 'Custom.form.php',
+			'icon' => 'unraid.png',
+			'os' => 'unraid'
+		],
 		'VyOS' => [
 			'form' => 'Custom.form.php',
 			'icon' => 'vyos.png',


### PR DESCRIPTION
It looks like this is all we need to add a basic VM template for unRAID?

Having a VM template will streamline the process for running an unRAID VM on an unRAID host per https://forums.lime-technology.com/topic/60106-guide-how-to-install-an-unraid-vm-on-an-unraid-host/

It would be great to get this in to 6.4, as it will make it that much easier for people to test 6.5 in a VM