### PR TITLE
Display message if docker service fails to start

### DIFF
--- a/plugins/dynamix.docker.manager/Docker.page
+++ b/plugins/dynamix.docker.manager/Docker.page
@@ -19,4 +19,8 @@ if ($var['fsState'] != "Started") {
   echo "<p class='notice'>Array must be <span class='strong big'>started</span> to view Docker containers.</p>";
   return;
 }
+if ( !is_file('/var/run/dockerd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/dockerd.pid'))) ) {
+  echo "<p class='notice'>Docker Service failed to start.</p>";
+	exit;
+}
 ?>

--- a/plugins/dynamix.docker.manager/Docker.page
+++ b/plugins/dynamix.docker.manager/Docker.page
@@ -21,6 +21,6 @@ if ($var['fsState'] != "Started") {
 }
 if ( !is_file('/var/run/dockerd.pid') || (!is_dir('/proc/'.@file_get_contents('/var/run/dockerd.pid'))) ) {
   echo "<p class='notice'>Docker Service failed to start.</p>";
-	exit;
+  return;
 }
 ?>


### PR DESCRIPTION
Occasionally, the array is started but the docker service fails to start (unmountable docker.img as an example)  
Toss up a message instead of simply displaying a blank page