### PR TITLE
Fix docker updates occasionally trying to remove wrong image

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -896,14 +896,18 @@ class DockerClient {
 
 
 	public function getImageID($Image) {
+ 		if ( ! strpos($Image,":") ) {
+			$Image .= ":latest";
+		}
 		foreach ($this->getDockerImages() as $img) {
-			if (preg_match("%" . preg_quote($Image, "%") . "%", $img["Tags"][0])) {
-				return $img["Id"];
+			foreach ($img['Tags'] as $tag) {
+				if ( $Image == $tag ) {
+					return $img["Id"];
+				}
 			}
 		}
 		return null;
 	}
-
 
 	public function getImageName($id) {
 		foreach ($this->getDockerImages() as $img) {
@@ -913,7 +917,6 @@ class DockerClient {
 		}
 		return null;
 	}
-
 
 	private function usedBy($imageId) {
 		$out = [];


### PR DESCRIPTION
https://forums.lime-technology.com/topic/57985-docker-failure-to-remove-orphan-image-due-to-similar-named-image/

Also handles rare edge case of multiple containers installed with different tags all referring to an identical image at the time of upgrade