### PR TITLE
Check for connectivity prior to updating docker updates

### DIFF
--- a/plugins/dynamix.docker.manager/scripts/dockerupdate.php
+++ b/plugins/dynamix.docker.manager/scripts/dockerupdate.php
@@ -29,6 +29,10 @@ foreach ($argv as $arg) {
 }
 
 if (!isset($check)) {
+  system("ping -c 1 github.com > /dev/null 2>&1",$retValue);
+  if ( $retValue ) {
+    exit(0);
+  }
   echo " Updating templates... ";
   $DockerTemplates->downloadTemplates();
   echo " Updating info... ";


### PR DESCRIPTION
At array start, if the network is invalid, it can take quite a while (20 minutes) for the cumulative timeouts on the template checks / updates before the array is fully functional.

Primarily affects those users running pfSense in a VM where no network access happens until the VM is started, and this can take up to 20 minutes in this situation.  Alternatively, if the user simply has their network cable unplugged, any VM's can take up to 20 minutes to start.

Many feature reqs / defect reports about this over the years.