### PR TITLE
Add support link to docker context menus

### DIFF
--- a/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/plugins/dynamix.docker.manager/DockerContainers.page
@@ -84,7 +84,8 @@ img.stopped{opacity:0.3;}
 			$updateStatus   = ($updateStatus == "true" || $updateStatus == "undef") ? 'true' : 'false';
 			$running        = ($ct['Running']) ? 'true' : 'false';
 			$webGuiUrl      = $info[$name]['url'];
-			$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info[$name]['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"]);
+			$Support        = $ct['Support'];
+			$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info[$name]['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"], addslashes($info[$name]['Support']));
 			$shape          = ($ct["Running"]) ? "play" : "square";
 			$status         = ($ct["Running"]) ? "started" : "stopped";
 
@@ -207,8 +208,8 @@ img.stopped{opacity:0.3;}
 <input type="button" onclick="addContainer()" value="Add Container"/>
 <input type="button" onclick="reloadUpdate()" value="Check for Updates"/>
 
-<script src="/webGui/javascript/jquery.switchbutton.js"></script>
-<script src="/plugins/dynamix.docker.manager/javascript/docker.js"></script>
+<script src="<?autov('/webGui/javascript/jquery.switchbutton.js')?>"></script>
+<script src="<?autov('/plugins/dynamix.docker.manager/javascript/docker.js')?>"></script>
 <script>
 <?if ($display['resize']):?>
 function resize(bind) {

--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -334,6 +334,9 @@ class DockerTemplates {
 			$Registry = $this->getTemplateValue($image, "Registry");
 			$tmp['registry'] = ($Registry) ? $Registry : null;
 
+			$Support = $this->getTemplateValue($image,"Support");
+			$tmp['Support'] = ($Support) ? $Support : null;
+			
 			if (!$tmp['updated'] || $reload) {
 				if ($reload) $DockerUpdate->reloadUpdateStatus($image);
 				$vs = $DockerUpdate->getUpdateStatus($image);

--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -1,6 +1,6 @@
 var eventURL = "/plugins/dynamix.docker.manager/include/Events.php";
 
-function addDockerContainerContext(container, image, template, started, update, autostart, webui, id) {
+function addDockerContainerContext(container, image, template, started, update, autostart, webui, id, Support="") {
   var opts = [{header: container, image: "/plugins/dynamix.docker.manager/images/dynamix.docker.manager.png"}];
   if (started && (webui !== "" && webui != "#")) {
     opts.push({text: 'WebUI', icon: 'fa-globe', href: webui, target: '_blank'});
@@ -25,6 +25,9 @@ function addDockerContainerContext(container, image, template, started, update, 
   }
   opts.push({divider: true});
   opts.push({text: 'Remove', icon: 'fa-trash', action: function(e){ e.preventDefault(); rmContainer(container, image, id); }});
+	if (Support) {
+		opts.push({text: 'Support', icon: 'fa-question', href: Support, target: '_blank'});
+	}
   context.attach('#context-'+container, opts);
 }
 

--- a/plugins/dynamix/DashboardApps.page
+++ b/plugins/dynamix/DashboardApps.page
@@ -77,10 +77,9 @@ foreach ($allContainers as $ct) {
 	$updateStatus   = ($updateStatus == "true" or $updateStatus == "undef" ) ? 'true' : 'false';
 	$running        = ($ct['Running']) ? 'true' : 'false';
 	$webGuiUrl      = $info['url'];
-	$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"] );
+	$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"], $info["Support"] );
 	$shape          = ($ct["Running"]) ? "play" : "square";
 	$status         = ($ct["Running"]) ? "started" : "stopped";
-
 	$Icon           = $info['icon'];
 	if (!$Icon) {
 		$Icon = "/plugins/dynamix.docker.manager/images/question.png";
@@ -171,8 +170,8 @@ foreach ($allVMs as $name) {
 ?>
 <div id="noapps">No apps available to show</div>
 </div>
-<script src="/webGui/javascript/jquery.switchbutton.js"></script>
-<script src="/plugins/dynamix.docker.manager/javascript/docker.js"></script>
+<script src="<?autov('/webGui/javascript/jquery.switchbutton.js')?>"></script>
+<script src="<?autov('/plugins/dynamix.docker.manager/javascript/docker.js')?>"></script>
 <script>
 function ajaxVMDispatch(currentstate, params){
   $.post("/plugins/dynamix.vm.manager/VMajax.php", params, function( data ) {


### PR DESCRIPTION
Will only work for containers added since Add Container.page supported the support entry (6.4.0-rc something).  For containers installed on 6.3.5 the support menu will not appear