### PR TITLE
Add in Support & Project Links to Docker Context Menus

### DIFF
--- a/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/plugins/dynamix.docker.manager/DockerContainers.page
@@ -84,7 +84,10 @@ img.stopped{opacity:0.3;}
 			$updateStatus   = ($updateStatus == "true" || $updateStatus == "undef") ? 'true' : 'false';
 			$running        = ($ct['Running']) ? 'true' : 'false';
 			$webGuiUrl      = $info[$name]['url'];
-			$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info[$name]['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"]);
+			$Support        = $ct['Support'];
+			$Project        = $ct['Project'];
+
+			$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s', '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info[$name]['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"], addslashes($info[$name]['Support']),addslashes($info[$name]['Project']));
 			$shape          = ($ct["Running"]) ? "play" : "square";
 			$status         = ($ct["Running"]) ? "started" : "stopped";
 
@@ -207,8 +210,8 @@ img.stopped{opacity:0.3;}
 <input type="button" onclick="addContainer()" value="Add Container"/>
 <input type="button" onclick="reloadUpdate()" value="Check for Updates"/>
 
-<script src="/webGui/javascript/jquery.switchbutton.js"></script>
-<script src="/plugins/dynamix.docker.manager/javascript/docker.js"></script>
+<script src="<?autov('/webGui/javascript/jquery.switchbutton.js')?>"></script>
+<script src="<?autov('/plugins/dynamix.docker.manager/javascript/docker.js')?>"></script>
 <script>
 <?if ($display['resize']):?>
 function resize(bind) {

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -263,7 +263,7 @@ function xmlToVar($xml) {
   $out['MyIP']        = isset($xml->MyIP) ? xml_decode($xml->MyIP) : '';
   $out['Privileged']  = xml_decode($xml->Privileged);
   $out['Support']     = xml_decode($xml->Support);
-	$out['Project']     = xml_decode($xml->Project);
+  $out['Project']     = xml_decode($xml->Project);
   $out['Overview']    = stripslashes(xml_decode($xml->Overview));
   $out['Category']    = xml_decode($xml->Category);
   $out['WebUI']       = xml_decode($xml->WebUI);
@@ -1322,7 +1322,7 @@ optgroup.title{background-color:#625D5D;color:#FFFFFF;text-align:center;margin-t
           </blockquote>
         </td>
       </tr>
-			<tr class="<?=$authoring;?>">
+      <tr class="<?=$authoring;?>">
         <td>Project Page:</td>
         <td><input type="text" name="contProject"></td>
       </tr>

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -207,6 +207,10 @@ function postToXML($post, $setOwnership = false) {
   $xml->ExtraParams        = xml_encode($post['contExtraParams']);
   $xml->PostArgs           = xml_encode($post['contPostArgs']);
   $xml->DateInstalled      = xml_encode(time());
+  $xml->DonateText         = xml_encode($post['contDonateText']);
+  $xml->DonateLink         = xml_encode($post['contDonateLink']);
+  $xml->DonateImg          = xml_encode($post['contDonateImg']);
+  $xml->MinVer             = xml_encode($post['contMinVer']);
 
   # V1 compatibility
   $xml->Description      = xml_encode($post['contOverview']);
@@ -271,6 +275,10 @@ function xmlToVar($xml) {
   $out['Icon']        = xml_decode($xml->Icon);
   $out['ExtraParams'] = xml_decode($xml->ExtraParams);
   $out['PostArgs']    = xml_decode($xml->PostArgs);
+  $out['DonateText']  = xml_decode($xml->DonateText);
+  $out['DonateLink']  = xml_decode($xml->DonateLink);
+  $out['DonateImg']   = (xml_decode($xml->DonateImage)) ? xml_decode($xml->DonateImage) : xml_decode($xml->DonateImg); # Various authors use different tags. DonateImg is the official spec
+  $out['MinVer']      = xml_decode($xml->MinVer);
 
   $out['Config'] = [];
   if (isset($xml->Config)) {
@@ -1333,6 +1341,50 @@ optgroup.title{background-color:#625D5D;color:#FFFFFF;text-align:center;margin-t
           </blockquote>
         </td>
       </tr>
+      <tr class="<?=$authoring;?>">
+        <td>Minimum unRAID version:</td>
+        <td><input type="text" name="contMinVer"></td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td colspan="2">
+          <blockquote class="inline_help">
+            <p>Minimum unRAID version required to run this container.  Enforced by the Apps Tab on Installation.  If there is no minimum version of unRaid required to run the container, leave blank.  Note that any container using 32 bit binaries should have a minimum version set to 6.4.0</p>
+          </blockquote>
+        </td>
+      </tr>			
+			<tr class="<?=$authoring;?>">
+        <td>Donation Text:</td>
+        <td><input type="text" name="contDonateText"></td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td colspan="2">
+          <blockquote class="inline_help">
+            <p>Text to appear on Donation Links Within The Apps Tab</p>
+          </blockquote>
+        </td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td>Donation Image:</td>
+        <td><input type="text" name="contDonateImg"></td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td colspan="2">
+          <blockquote class="inline_help">
+            <p>Link to the image used for Donation Links Within The Apps Tab</p>
+          </blockquote>
+        </td>
+      </tr>			
+      <tr class="<?=$authoring;?>">
+        <td>Donation Link:</td>
+        <td><input type="text" name="contDonateLink"></td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td colspan="2">
+          <blockquote class="inline_help">
+            <p>Link to the donation page.  If using donation's, both the image and link must be set</p>
+          </blockquote>
+        </td>
+      </tr>			
       <tr class="advanced">
         <td>Docker Hub URL:</td>
         <td><input type="text" name="contRegistry"></td>

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -207,10 +207,6 @@ function postToXML($post, $setOwnership = false) {
   $xml->ExtraParams        = xml_encode($post['contExtraParams']);
   $xml->PostArgs           = xml_encode($post['contPostArgs']);
   $xml->DateInstalled      = xml_encode(time());
-  $xml->DonateText         = xml_encode($post['contDonateText']);
-  $xml->DonateLink         = xml_encode($post['contDonateLink']);
-  $xml->DonateImg          = xml_encode($post['contDonateImg']);
-  $xml->MinVer             = xml_encode($post['contMinVer']);
 
   # V1 compatibility
   $xml->Description      = xml_encode($post['contOverview']);
@@ -275,10 +271,6 @@ function xmlToVar($xml) {
   $out['Icon']        = xml_decode($xml->Icon);
   $out['ExtraParams'] = xml_decode($xml->ExtraParams);
   $out['PostArgs']    = xml_decode($xml->PostArgs);
-  $out['DonateText']  = xml_decode($xml->DonateText);
-  $out['DonateLink']  = xml_decode($xml->DonateLink);
-  $out['DonateImg']   = (xml_decode($xml->DonateImage)) ? xml_decode($xml->DonateImage) : xml_decode($xml->DonateImg); # Various authors use different tags. DonateImg is the official spec
-  $out['MinVer']      = xml_decode($xml->MinVer);
 
   $out['Config'] = [];
   if (isset($xml->Config)) {
@@ -1341,50 +1333,6 @@ optgroup.title{background-color:#625D5D;color:#FFFFFF;text-align:center;margin-t
           </blockquote>
         </td>
       </tr>
-      <tr class="<?=$authoring;?>">
-        <td>Minimum unRAID version:</td>
-        <td><input type="text" name="contMinVer"></td>
-      </tr>
-      <tr class="<?=$authoring;?>">
-        <td colspan="2">
-          <blockquote class="inline_help">
-            <p>Minimum unRAID version required to run this container.  Enforced by the Apps Tab on Installation.  If there is no minimum version of unRaid required to run the container, leave blank.  Note that any container using 32 bit binaries should have a minimum version set to 6.4.0</p>
-          </blockquote>
-        </td>
-      </tr>			
-			<tr class="<?=$authoring;?>">
-        <td>Donation Text:</td>
-        <td><input type="text" name="contDonateText"></td>
-      </tr>
-      <tr class="<?=$authoring;?>">
-        <td colspan="2">
-          <blockquote class="inline_help">
-            <p>Text to appear on Donation Links Within The Apps Tab</p>
-          </blockquote>
-        </td>
-      </tr>
-      <tr class="<?=$authoring;?>">
-        <td>Donation Image:</td>
-        <td><input type="text" name="contDonateImg"></td>
-      </tr>
-      <tr class="<?=$authoring;?>">
-        <td colspan="2">
-          <blockquote class="inline_help">
-            <p>Link to the image used for Donation Links Within The Apps Tab</p>
-          </blockquote>
-        </td>
-      </tr>			
-      <tr class="<?=$authoring;?>">
-        <td>Donation Link:</td>
-        <td><input type="text" name="contDonateLink"></td>
-      </tr>
-      <tr class="<?=$authoring;?>">
-        <td colspan="2">
-          <blockquote class="inline_help">
-            <p>Link to the donation page.  If using donation's, both the image and link must be set</p>
-          </blockquote>
-        </td>
-      </tr>			
       <tr class="advanced">
         <td>Docker Hub URL:</td>
         <td><input type="text" name="contRegistry"></td>

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -198,6 +198,7 @@ function postToXML($post, $setOwnership = false) {
   $xml->MyIP               = xml_encode($post['contMyIP']);
   $xml->Privileged         = (strtolower($post["contPrivileged"]) == 'on') ? 'true' : 'false';
   $xml->Support            = xml_encode($post['contSupport']);
+	$xml->Project            = xml_encode($post['contProject']);
   $xml->Overview           = xml_encode($post['contOverview']);
   $xml->Category           = xml_encode($post['contCategory']);
   $xml->WebUI              = xml_encode(trim($post['contWebUI']));
@@ -262,6 +263,7 @@ function xmlToVar($xml) {
   $out['MyIP']        = isset($xml->MyIP) ? xml_decode($xml->MyIP) : '';
   $out['Privileged']  = xml_decode($xml->Privileged);
   $out['Support']     = xml_decode($xml->Support);
+	$out['Project']     = xml_decode($xml->Project);
   $out['Overview']    = stripslashes(xml_decode($xml->Overview));
   $out['Category']    = xml_decode($xml->Category);
   $out['WebUI']       = xml_decode($xml->WebUI);
@@ -1317,6 +1319,17 @@ optgroup.title{background-color:#625D5D;color:#FFFFFF;text-align:center;margin-t
         <td colspan="2">
           <blockquote class="inline_help">
             <p>Link to a support thread on Lime-Technology's forum.</p>
+          </blockquote>
+        </td>
+      </tr>
+			<tr class="<?=$authoring;?>">
+        <td>Project Page:</td>
+        <td><input type="text" name="contProject"></td>
+      </tr>
+      <tr class="<?=$authoring;?>">
+        <td colspan="2">
+          <blockquote class="inline_help">
+            <p>Link to the project page (eg: www.plex.tv)</p>
           </blockquote>
         </td>
       </tr>

--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -333,6 +333,12 @@ class DockerTemplates {
 
 			$Registry = $this->getTemplateValue($image, "Registry");
 			$tmp['registry'] = ($Registry) ? $Registry : null;
+			
+			$Support = $this->getTemplateValue($image, "Support");
+			$tmp['Support'] = ($Support) ? $Support : null;
+			
+			$Project = $this->getTemplateValue($image, "Project");
+			$tmp['Project'] = ($Project) ? $Project : null;
 
 			if (!$tmp['updated'] || $reload) {
 				if ($reload) $DockerUpdate->reloadUpdateStatus($image);

--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -1,6 +1,6 @@
 var eventURL = "/plugins/dynamix.docker.manager/include/Events.php";
 
-function addDockerContainerContext(container, image, template, started, update, autostart, webui, id, Support="", Project="") {
+function addDockerContainerContext(container, image, template, started, update, autostart, webui, id, Support, Project) {
   var opts = [{header: container, image: "/plugins/dynamix.docker.manager/images/dynamix.docker.manager.png"}];
   if (started && (webui !== "" && webui != "#")) {
     opts.push({text: 'WebUI', icon: 'fa-globe', href: webui, target: '_blank'});

--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -1,6 +1,6 @@
 var eventURL = "/plugins/dynamix.docker.manager/include/Events.php";
 
-function addDockerContainerContext(container, image, template, started, update, autostart, webui, id) {
+function addDockerContainerContext(container, image, template, started, update, autostart, webui, id, Support="", Project="") {
   var opts = [{header: container, image: "/plugins/dynamix.docker.manager/images/dynamix.docker.manager.png"}];
   if (started && (webui !== "" && webui != "#")) {
     opts.push({text: 'WebUI', icon: 'fa-globe', href: webui, target: '_blank'});
@@ -25,6 +25,13 @@ function addDockerContainerContext(container, image, template, started, update, 
   }
   opts.push({divider: true});
   opts.push({text: 'Remove', icon: 'fa-trash', action: function(e){ e.preventDefault(); rmContainer(container, image, id); }});
+	if (Support) {
+		opts.push({divider: true});
+		opts.push({text: 'Support', icon: 'fa-question', href: Support, target: '_blank'});
+	}
+	if (Project) {
+		opts.push({text: 'Project Page', icon: 'fa-life-ring', href: Project, target: '_blank'});
+	}
   context.attach('#context-'+container, opts);
 }
 

--- a/plugins/dynamix/DashboardApps.page
+++ b/plugins/dynamix/DashboardApps.page
@@ -77,7 +77,7 @@ foreach ($allContainers as $ct) {
 	$updateStatus   = ($updateStatus == "true" or $updateStatus == "undef" ) ? 'true' : 'false';
 	$running        = ($ct['Running']) ? 'true' : 'false';
 	$webGuiUrl      = $info['url'];
-	$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"] );
+	$contextMenus[] = sprintf("addDockerContainerContext('%s', '%s', '%s', %s, %s, %s, '%s', '%s', '%s', '%s');", addslashes($ct['Name']), addslashes($ct['ImageId']), addslashes($info['template']), $running, $updateStatus, $is_autostart, addslashes($webGuiUrl), $ct["Id"], $info["Support"],$info["Project"] );
 	$shape          = ($ct["Running"]) ? "play" : "square";
 	$status         = ($ct["Running"]) ? "started" : "stopped";
 
@@ -133,9 +133,9 @@ foreach ($allVMs as $name) {
 ?>
 <div id="noapps">No apps available to show</div>
 </div>
-<script src="/webGui/javascript/jquery.switchbutton.js"></script>
-<script src="/plugins/dynamix.docker.manager/javascript/docker.js"></script>
-<script src="/plugins/dynamix.vm.manager/javascript/vmmanager.js"></script>
+<script src="<?autov('/webGui/javascript/jquery.switchbutton.js')?>"></script>
+<script src="<?autov('/plugins/dynamix.docker.manager/javascript/docker.js')?>"></script>
+<script src="<?autov('/plugins/dynamix.vm.manager/javascript/vmmanager.js')?>"></script>
 <script>
 $(function() {
 	if ($.cookie('dashapps_view_mode') == 'startedonly') {


### PR DESCRIPTION
Every container installed via CA should already have the Support Link present (if installed post 6.2)
Majority of apps in CA also have a project link present (and passed to dockerMan), but thus far dockerMan hasn't saved that entry on user templates, so the Project link on the context menus will only appear for new containers added after the PR is approved.  (After published, I'll probably post a script to update everyone's user-templates with the appropriate Project URL's)

Additionally, dockerMan template authoring mode will also now support the most common CA xml entries (but nowhere near all) that template authors currently have to add manually to the generated xml file
![untitled1](https://user-images.githubusercontent.com/11369569/35474763-ae348acc-0360-11e8-87bb-f3ea15fc3007.png)
