### PR TITLE
Add ability for pluginMan to not install the .plg file

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -495,13 +495,13 @@ if ($method == "install") {
   // Bergware change: add user or system plugin selection - deprecated
   $plugintype = plugin("plugintype", $plugin_file, $error);
   $target = $plugintype != "system" ? "/boot/config/plugins/$plugin" : "/boot/plugins/$plugin";
-	if ( ! plugin("noInstall",$plugin_file,$error) ) {
-		if ($target != $plugin_file) copy($plugin_file, $target);
-		symlink($target, "/var/log/plugins/$plugin");
-		echo "plugin: installed\n";
-	} else {
-		echo "Script: executed\n";
-	}
+  if ( ! plugin("noInstall",$plugin_file,$error) ) {
+    if ($target != $plugin_file) copy($plugin_file, $target);
+    symlink($target, "/var/log/plugins/$plugin");
+  echo "plugin: installed\n";
+  } else {
+    echo "Script: executed\n";
+  }
   exit(0);
 }
 

--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -495,9 +495,13 @@ if ($method == "install") {
   // Bergware change: add user or system plugin selection - deprecated
   $plugintype = plugin("plugintype", $plugin_file, $error);
   $target = $plugintype != "system" ? "/boot/config/plugins/$plugin" : "/boot/plugins/$plugin";
-  if ($target != $plugin_file) copy($plugin_file, $target);
-  symlink($target, "/var/log/plugins/$plugin");
-  echo "plugin: installed\n";
+	if ( ! plugin("noInstall",$plugin_file,$error) ) {
+		if ($target != $plugin_file) copy($plugin_file, $target);
+		symlink($target, "/var/log/plugins/$plugin");
+		echo "plugin: installed\n";
+	} else {
+		echo "Script: executed\n";
+	}
   exit(0);
 }
 


### PR DESCRIPTION
Currently, to use the plugin manager as an easy method of running one-off scripts that DO NOT need to be re-run at boot time, the script needs to exit with a non-zero return code to force pluginMan to not copy the .plg to /boot/config/plugins.  Ideally, the script should exit with a zero return code for successful execution.

The trigger for this is a new <PLUGIN> attribute of "noInstall" When its value is non-null, the .plg will not get saved to /boot/config/plugins, but the .plg can still exit with a proper zero return code.

Admittedly, not too much call for this, but it would have come in handy for my Support / Project template update script for 6.4.1-rc2