### PR TITLE
Docker: Don't automatically update webUI entry on templates

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -480,7 +480,7 @@ class DockerUpdate{
 	public function updateUserTemplate($Container) {
 		$changed = false;
 		$DockerTemplates = new DockerTemplates();
-		$validElements = ['Support', 'Overview', 'Category', 'WebUI', 'Icon'];
+		$validElements = ['Support', 'Overview', 'Category', 'Icon'];
 		$validAttributes = ['Name', 'Default', 'Description', 'Display', 'Required', 'Mask'];
 
 		// Get user template file and abort if fail

--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -480,7 +480,7 @@ class DockerUpdate{
 	public function updateUserTemplate($Container) {
 		$changed = false;
 		$DockerTemplates = new DockerTemplates();
-		$validElements = ['Support', 'Overview', 'Category', 'Icon'];
+		$validElements = ['Support', 'Overview', 'Category', 'Project', 'Icon'];
 		$validAttributes = ['Name', 'Default', 'Description', 'Display', 'Required', 'Mask'];
 
 		// Get user template file and abort if fail


### PR DESCRIPTION
webUI being automatically updated by dockerMan on updates results in people that have as an example reverse proxied their containers and needing to have a different webUI always having to redo their changes.