### PR TITLE
Docker: Selectable Global Container Stop Time

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-text eol=lf
+* text = auto
 *.woff binary
 *.woff2 binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text = auto
+text eol=lf
 *.woff binary
 *.woff2 binary

--- a/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/plugins/dynamix.docker.manager/DockerSettings.page
@@ -815,17 +815,17 @@ function showLogOptions(log) {
     $('#DOCKER_LOG_OPTIONS').show('slow');
   }
 }
-
 function validateStopTime(entry) {
   entry = Math.abs(parseInt(entry));
-	if ( entry < 10 ) {
-	  entry = 10;
-	}
-	if ( entry > 30 ) {
-	  entry = 30;
-	}
-	$("#DOCKER_STOP_TIME").val(entry);
+  if ( entry < 10 ) {
+    entry = 10;
+  }
+  if ( entry > 30 ) {
+    entry = 30;
+  }
+  $("#DOCKER_STOP_TIME").val(entry);
 }
+
 $(function() {
   $("#applyBtn").click(function(){
     if (!checkDHCP() || !checkIP()) return;

--- a/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/plugins/dynamix.docker.manager/DockerSettings.page
@@ -236,6 +236,11 @@ Template Authoring Mode:
 
 > If set to **Yes**, when creating/editing containers the interface will be present with some extra fields related to template authoring.
 
+Wait time in seconds when stopping containers:
+: <input id="DOCKER_STOP_TIME" type="number" name="DOCKER_STOP_TIME" value="<?=$dockercfg['DOCKER_STOP_TIME']?>"  style="width:50px;" onchange='validateStopTime(this.value);' required="required">
+
+> When stopping a container, wait this many seconds for the container to gracefully exit before forcibly killing it (Minimum 10 seconds, Maximum 30 seconds)
+
 Preserve user defined networks:
 : <select name="DOCKER_USER_NETWORKS" class="narrow">
   <?=mk_option($dockercfg['DOCKER_USER_NETWORKS'], 'remove', 'No')?>
@@ -809,6 +814,17 @@ function showLogOptions(log) {
   } else {
     $('#DOCKER_LOG_OPTIONS').show('slow');
   }
+}
+
+function validateStopTime(entry) {
+  entry = Math.abs(parseInt(entry));
+	if ( entry < 10 ) {
+	  entry = 10;
+	}
+	if ( entry > 30 ) {
+	  entry = 30;
+	}
+	$("#DOCKER_STOP_TIME").val(entry);
 }
 $(function() {
   $("#applyBtn").click(function(){

--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -38,6 +38,7 @@ function docker($cmd, &$var=null) {
 # Docker configuration file - guaranteed to exist
 $docker_cfgfile = '/boot/config/docker.cfg';
 $dockercfg = parse_ini_file($docker_cfgfile);
+$dockercfg['DOCKER_STOP_TIME'] = $dockercfg['DOCKER_STOP_TIME'] ?: 10;
 
 ######################################
 ##      DOCKERTEMPLATES CLASS       ##
@@ -678,7 +679,9 @@ class DockerClient {
 	}
 
 	public function stopContainer($id) {
-		$this->getDockerJSON("/containers/${id}/stop?t=10", 'POST', $code);
+		global $dockercfg;
+		
+		$this->getDockerJSON("/containers/${id}/stop?t={$dockercfg['DOCKER_STOP_TIME']}", 'POST', $code);
 		$this::$allContainersCache = null; // flush cache
 		$codes = [
 			'204' => true, // No error
@@ -690,7 +693,9 @@ class DockerClient {
 	}
 
 	public function restartContainer($id) {
-		$this->getDockerJSON("/containers/${id}/restart?t=10", 'POST', $code);
+		global $dockercfg;
+		
+		$this->getDockerJSON("/containers/${id}/restart?t={$dockercfg['DOCKER_STOP_TIME']}", 'POST', $code);
 		$this::$allContainersCache = null; // flush cache
 		$codes = [
 			'204' => true, // No error


### PR DESCRIPTION
Docker defaults to 10 seconds for a graceful stop before forcibly attempting to kill the container.  Some containers may require more time to exit.