### PR TITLE
Docker skip hidden files when listing directories

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -72,6 +72,7 @@ class DockerTemplates {
 		foreach ($iter as $path => $fileinfo) {
 			$fext = $fileinfo->getExtension();
 			if ($ext && $ext != $fext) continue;
+			if (substr(basename($path),0,1) == ".")  continue;
 			if ($fileinfo->isFile()) $paths[] = ['path' => $path, 'prefix' => basename(dirname($path)), 'name' => $fileinfo->getBasename(".$fext")];
 		}
 		return $paths;


### PR DESCRIPTION
Solves the problem with dockerMan pumping out tons of simpleXML errors when a Mac creates its ._ files

See https://lime-technology.com/forums/topic/70636-beta-diskspeed-hard-drive-benchmarking-unraid-6/?page=5&tab=comments#comment-653133  (Hasn't really appeared prior because this template was originally published as a .xml the user had to copy manually onto the flash drive)