### PR TITLE
Add support for Docker Labels to Docker plugin

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -446,7 +446,7 @@ function xmlToCommand($xml, $create_paths=false) {
     }
   }
   $postArgs = explode(";",$xml['PostArgs']);
-  $cmd = sprintf($docroot.'/plugins/dynamix.docker.manager/scripts/docker create %s %s %s %s %s %s %s %s %s %s %s',
+  $cmd = sprintf($docroot.'/plugins/dynamix.docker.manager/scripts/docker create %s %s %s %s %s %s %s %s %s %s %s %s',
          $cmdName, $cmdNetwork, $cmdMyIP, $cmdPrivileged, implode(' -e ', $Variables), implode(' -l ', $Labels), implode(' -p ', $Ports), implode(' -v ', $Volumes), implode(' --device=', $Devices), $xml['ExtraParams'], escapeshellarg($xml['Repository']), $postArgs[0]);
   return [preg_replace('/\s+/', ' ', $cmd), $xml['Name'], $xml['Repository']];
 }


### PR DESCRIPTION
Docker object labels:
https://docs.docker.com/config/labels-custom-metadata/

More and more containers are taking advantage of container metadata
where environment variables are not necessary.

Traefik is a good example:
https://docs.traefik.io/configuration/backends/docker/#on-containers