### PR TITLE
Strip HTML from back-end

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -531,7 +531,7 @@ class DockerClient {
 		'304' => 'Container already started',
 		'400' => 'Bad parameter',
 		'404' => 'No such container',
-		'409' => 'Image can not be deleted<br><i>In use by other container(s)</i>',
+		'409' => 'Image can not be deleted, in use by other container(s)',
 		'500' => 'Server error'
 	];
 


### PR DESCRIPTION
HTML tags are converted to HTML entities somewhere along the chain and `CreateDocker.php` generates:

`addLog('<b>Error: Image can not be deleted&lt;br&gt;&lt;i&gt;In use by other container(s)&lt;/i&gt;</b>');` 

![screen shot 2018-06-01 at 02 27 32](https://user-images.githubusercontent.com/5107843/40816307-277e4bc6-6544-11e8-95ac-f207b5c61076.png)