### PR TITLE
Correct docker container icon name generation

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -291,7 +291,7 @@ class DockerTemplates {
 	public function getIcon($Repository) {
 		global $docroot, $dockerManPaths;
 		$imgUrl = $this->getTemplateValue($Repository, 'Icon');
-		preg_match_all("/(.*?):([\w]*$)/i", $Repository, $matches);
+		preg_match_all("/(.*?):([\S]*$)/i", $Repository, $matches);
 		$name = preg_replace("%\/|\\\%", '-', $matches[1][0]);
 		$version = $matches[2][0];
 		$iconRAM = sprintf('%s/%s-%s-%s.png', $dockerManPaths['images-ram'], $name, $version, 'icon');


### PR DESCRIPTION
Dockerman is generating incorrect icon names for certain image tags
examples:
openhab/openhab:2.3.0-amd64-debian -> --icon.png
binhex/emby:1.4.0 -> --icon.png

Seems the regex for extracting the icon name from the image tag is insufficient.