### PR TITLE
Plugin List: Show support thread if attribute exists

### DIFF
--- a/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -78,6 +78,9 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
 //version
   $version = plugin('version',$plugin_file) ?: "unknown";
   $date = str_replace('.','',$version);
+//support
+	$support = plugin('support',$plugin_file) ?: "";
+	$support = $support ? "<a href='$support' target='_blank'>Support Thread</a>" : "";
 //category
   $category = plugin('category',$plugin_file) ?: (strpos($version,'-')!==false ? 'next' : 'stable');
 //status
@@ -118,7 +121,7 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
   $empty = false;
   echo "<tr id=\"".str_replace(['.',' ','_'],'',basename($plugin_file,'.plg'))."\">";
   echo "<td style='vertical-align:top;width:64px'><p style='text-align:center'>$link</p></td>";
-  echo "<td><span class='desc_readmore' style='display:block'>$desc</span></td>";
+  echo "<td><span class='desc_readmore' style='display:block'>$desc</span> $support</td>";
   echo "<td>$author</td>";
   echo "<td data='$date'>$version</td>";
   echo "<td data='$rank'>$status</td>";

--- a/plugins/dynamix.plugin.manager/include/ShowPlugins.php
+++ b/plugins/dynamix.plugin.manager/include/ShowPlugins.php
@@ -79,8 +79,8 @@ foreach (glob($plugins,GLOB_NOSORT) as $plugin_link) {
   $version = plugin('version',$plugin_file) ?: "unknown";
   $date = str_replace('.','',$version);
 //support
-	$support = plugin('support',$plugin_file) ?: "";
-	$support = $support ? "<a href='$support' target='_blank'>Support Thread</a>" : "";
+  $support = plugin('support',$plugin_file) ?: "";
+  $support = $support ? "<a href='$support' target='_blank'>Support Thread</a>" : "";
 //category
   $category = plugin('category',$plugin_file) ?: (strpos($version,'-')!==false ? 'next' : 'stable');
 //status


### PR DESCRIPTION
Supports a new attribute on plugins (**support**) which will contain a link to the appropriate support thread in the forum. 
Easiest way to test is to remove then reinstall CA which now has that attribute present.
If this PR does get added to dynamix, then at time of release I would publish a script to update all the .plg's present on a user's system with the appropriate attribute, and also have CA on installation of a .plg automatically add it to the .plg if it doesn't already exist (since I insist that CA's XML file has a support entry)
Only dmacias would have to adjust his README.md files as he is the only one who includes a link to support already contained within it.
