### PR TITLE
Remove control codes, and extended ascii characters from plugin urls …

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -439,6 +439,7 @@ if ($argc < 3) {
 //
 $unraid = parse_ini_file('/etc/unraid-version');
 if ($method == "install") {
+  $argv[2] = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $argv[2]);
   echo "plugin: installing: $argv[2]\n";
   // check for URL
   if ((strpos($argv[2], "http://") === 0) || (strpos($argv[2], "https://") === 0)) {


### PR DESCRIPTION
…on install

Every once in a while, a copy / paste from a browser of CA's URL posted on the forum winds up with unicode and/or control characters in the middle of the URL, which prevents installation.  (https://lime-technology.com/forums/topic/38582-plug-in-community-applications/?page=85&tab=comments#comment-669454  and  https://lime-technology.com/forums/topic/38582-plug-in-community-applications/?page=84&tab=comments#comment-664991 )


Just replace them with a null character.

Probably geographically related.