### PR TITLE
dockerMan: Avoid filename collisions on FAT32

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -81,7 +81,16 @@ if (isset($_POST['contName'])) {
   $userTmplDir = $dockerManPaths['templates-user'];
   if (!is_dir($userTmplDir)) mkdir($userTmplDir, 0777, true);
   if ($Name) {
-    $filename = sprintf('%s/my-%s.xml', $userTmplDir, $Name);
+    $filename = sprintf('%s/my-%s', $userTmplDir, $Name);
+	// look for FAT32 filename hits due to different case
+		$userTemplates = glob("$userTmplDir/*.xml");
+		foreach ($userTemplates as $tmpl) {
+			if ( ($tmpl != "$filename.xml") && (strcasecmp($tmpl,"$filename.xml") == 0) ) {
+				$filename .= " (1)";
+				break;
+			}
+		}
+		$filename .= ".xml";
     file_put_contents($filename, $postXML);
   }
   // Run dry

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -82,15 +82,15 @@ if (isset($_POST['contName'])) {
   if (!is_dir($userTmplDir)) mkdir($userTmplDir, 0777, true);
   if ($Name) {
     $filename = sprintf('%s/my-%s', $userTmplDir, $Name);
-	// look for FAT32 filename hits due to different case
-		$userTemplates = glob("$userTmplDir/*.xml");
-		foreach ($userTemplates as $tmpl) {
-			if ( ($tmpl != "$filename.xml") && (strcasecmp($tmpl,"$filename.xml") == 0) ) {
-				$filename .= " (1)";
-				break;
-			}
-		}
-		$filename .= ".xml";
+    // look for FAT32 filename hits due to different case
+    $userTemplates = glob("$userTmplDir/*.xml");
+    foreach ($userTemplates as $tmpl) {
+      if ( ($tmpl != "$filename.xml") && (strcasecmp($tmpl,"$filename.xml") == 0) ) {
+        $filename .= " (1)";
+        break;
+      }
+    }
+    $filename .= ".xml";
     file_put_contents($filename, $postXML);
   }
   // Run dry


### PR DESCRIPTION
Because under FAT32, my-plexmediaserver == my-PlexMediaServer.  Solves an edge case