### PR TITLE
Allow inline execution of exert without having to specify variable

### DIFF
--- a/plugins/dynamix/scripts/diagnostics
+++ b/plugins/dynamix/scripts/diagnostics
@@ -25,6 +25,7 @@ $folders = ['/boot','/boot/config','/boot/config/plugins','/boot/extra','/boot/s
 function exert($cmd, &$save=null) {
 // execute command with timeout of 30s
   exec("timeout -s9 30 $cmd", $save);
+  return implode("\n",$save);
 }
 
 function anonymize($text,$select) {


### PR DESCRIPTION
IE: loads.txt is not being generated correctly on 6.6-rc1