### PR TITLE
Revert docker run Security

### DIFF
--- a/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/plugins/dynamix.docker.manager/include/Helpers.php
@@ -436,9 +436,6 @@ function pullImage($name, $image, $echo=true) {
 }
 
 function execCommand($command, $echo=true) {
-  if ( dockerRunSecurity($command) ) {
-    $command = "logger 'docker command execution halted due to security violation (Bash command execution or redirection)'";
-  }
   // $command should have all its args already properly run through 'escapeshellarg'
   $descriptorspec = [
     0 => ['pipe', 'r'],   // stdin is a pipe that the child will read from
@@ -467,21 +464,6 @@ function execCommand($command, $echo=true) {
   $out = $retval ?  'The command failed.' : 'The command finished successfully!';
   if ($echo) echo '<script>addLog(\'<br><b>'.$out.'</b>\');</script>';
   return $retval===0;
-}
-
-function dockerRunSecurity($command) {
-  $testCommand = htmlspecialchars_decode($command);
-  $testCommand = str_replace("\'","",$testCommand);
-  $cmdSplit = explode("'",$testCommand);
-  for ($i=0; $i<count($cmdSplit); $i=$i+2) {
-    $tstCommand .= $cmdSplit[$i];
-  }
-  foreach ( [";","|",">","&&"] as $invalidChars ) {
-    if ( strpos($tstCommand,$invalidChars) ) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function getXmlVal($xml, $element, $attr=null, $pos=0) {


### PR DESCRIPTION
While I think this was a decent idea, in actual practice there are too many possibilities / permutations of quoting etc that can potentially result in a false positive and prevent the user from executing their container (has already happened twice).  Net result is that the security routine would have to be continually updated as more legit usages come to light.

Since the whole point of the original change was to prevent repository maintainers from maliciously executing arbitrary commands in the docker run and not to impact end-users at all, this will have to be purely enforced on CA's end instead where the permutations are far less because of only having to deal with a raw template