### PR TITLE
Add global CPU core pinning for containers

### DIFF
--- a/plugins/dynamix/CPUvms.page
+++ b/plugins/dynamix/CPUvms.page
@@ -119,6 +119,12 @@ function vm() {
     buttons(document.vm);
   });
 }
+function thread2containers(n) {
+  const selector = $('form[name=ct]').find(`[name$=":${n}"]`);
+  const checkboxes = selector.length;
+  const checked = selector.filter(':checked').length;
+  selector.prop('checked', (checkboxes - checked > checked ? true : false)).change();
+}
 function ct() {
   // fetch the current container assignments
   $.post('/webGui/include/CPUset.php',{id:'ct',cpus:'<?=$cpuset?>'},function(d){
@@ -126,9 +132,9 @@ function ct() {
     $('#table-ct').html(data[0]);
     $('#names-ct').val(data[1]);
     buttons(document.ct);
-    // inject global cpu pinning links
+    // inject thread to containers toggles
     $('form[name=ct]').find('thead tr th:gt(1)').each((i, elem) => {
-      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="javascript:void(0)" data-state="false" onclick="$(this).data('state', !$(this).data('state')); $('form[name=ct]').find('[name$=&quot;:$1&quot;]').prop('checked', $(this).data('state')).change()">$1</a>`);
+      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="#" onclick="thread2containers(this.innerText);return false;" title="Toggle thread to containers">$1</a>`);
     });
   });
 }

--- a/plugins/dynamix/CPUvms.page
+++ b/plugins/dynamix/CPUvms.page
@@ -133,9 +133,11 @@ function ct() {
     $('#names-ct').val(data[1]);
     buttons(document.ct);
     // inject thread to containers toggles
-    $('form[name=ct]').find('thead tr th:gt(1)').each((i, elem) => {
-      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="#" onclick="thread2containers(this.innerText);return false;" title="Toggle thread to containers">$1</a>`);
-    });
+    if($('a[onclick^="thread2containers"]').length === 0) {
+      $('form[name=ct]').find('thead tr th:gt(1)').each((i, elem) => {
+        elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="#" onclick="thread2containers(this.innerText);return false;" title="Toggle thread to containers">$1</a>`);
+      });
+    }
   });
 }
 function is() {

--- a/plugins/dynamix/CPUvms.page
+++ b/plugins/dynamix/CPUvms.page
@@ -128,7 +128,7 @@ function ct() {
     buttons(document.ct);
     // inject global cpu pinning links
     $('form[name=ct]').find('thead tr th:gt(1)').each((i, elem) => {
-      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="javascript:void(0)" data-state="false" onclick="$(this).data('state', !$(this).data('state')); $('form[name=ct]').find('[name$=&quot;:$1&quot;]').prop('checked', $(this).data('state'))">$1</a>`);
+      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="javascript:void(0)" data-state="false" onclick="$(this).data('state', !$(this).data('state')); $('form[name=ct]').find('[name$=&quot;:$1&quot;]').prop('checked', $(this).data('state')).change()">$1</a>`);
     });
   });
 }

--- a/plugins/dynamix/CPUvms.page
+++ b/plugins/dynamix/CPUvms.page
@@ -126,6 +126,10 @@ function ct() {
     $('#table-ct').html(data[0]);
     $('#names-ct').val(data[1]);
     buttons(document.ct);
+    // inject global cpu pinning links
+    $('form[name=ct]').find('thead tr th:gt(1)').each((i, elem) => {
+      elem.innerHTML = elem.innerHTML.replace(/(\d+)/g, `<a href="javascript:void(0)" data-state="false" onclick="$(this).data('state', !$(this).data('state')); $('form[name=ct]').find('[name$=&quot;:$1&quot;]').prop('checked', $(this).data('state'))">$1</a>`);
+    });
   });
 }
 function is() {


### PR DESCRIPTION
Should make possible to (re)allocate CPU resources across all containers faster. Currently, it requires manual clicking on thread numbers per container individually, which in a large pool of containers can be very repetitive. The change allows for thread numbers to be clickable, doing so enables or disables thread pinning across all containers.