### PR TITLE
Improve private docker registry support (correctly pulling and updating containers)

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -14,6 +14,8 @@
 <?
 $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
 
+require_once "$docroot/plugins/dynamix.docker.manager/include/Helpers.php";
+
 $dockerManPaths = [
 	'autostart-file' => "/var/lib/docker/unraid-autostart",
 	'update-status'  => "/var/lib/docker/unraid-update-status.json",

--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -785,7 +785,7 @@ class DockerClient {
 		if ( empty( $dockerConfig['auths'] ) || empty( $dockerConfig['auths'][ $matches[1] ] ) ) {
 			return false;
 		}
-		list($user, $password) = explode(':', base64_decode($dockerConfig['auths'][ $matches[1] ]));
+		list($user, $password) = explode(':', base64_decode($dockerConfig['auths'][ $matches[1] ]['auth']));
 
 		return [
 			'username'     => $user,

--- a/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/plugins/dynamix.docker.manager/include/Helpers.php
@@ -506,4 +506,17 @@ function getAllocations() {
   }
   return $ports;
 }
+
+function getCurlHandle($url, $method = 'GET') {
+	$ch = curl_init();
+	curl_setopt( $ch, CURLOPT_URL, $url );
+	curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+	if ($method === 'HEAD') {
+		curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, 'HEAD' );
+		curl_setopt( $ch, CURLOPT_HEADER, 1 );
+		curl_setopt( $ch, CURLOPT_NOBODY, true );
+    }
+
+    return $ch;
+}
 ?>


### PR DESCRIPTION
This is a rewrite to allow better support for private docker registries (in my case, free gitlab.com).
This rewrite is not tested on an unraid install, since I'm not sure how to set that up (see #400).

The code itself is tested in so far, as I ran it outside of unraid to get the api flow correctly and to make sure the `/root/.docker/config.json` is parsed correctly.

Following things could be problematic:
- Needs read access to `/root/.docker/config.json`
- Anybody wishing to use this would need to make sure `/root/.docker/config.json` is persistent across reboots

Otherwise it would basically be following a normal usage of private docker registries, for example Gitlab:
- Create gitlab account and repo, push docker image to docker repository
- Login to private docker repo via `docker login [...]` on unraid via ssh
- Installing and updating docker images via unraid webui should now work