### PR TITLE
Code change to prevent CA from modifying system file

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -176,9 +176,9 @@ if ($_GET['updateContainer']){
       stopContainer($Name);
     }
     // force kill container if still running after 10 seconds
-   	if ( ! $_GET['communityApplications'] ) {
-			removeContainer($Name);
-		}
+    if ( ! $_GET['communityApplications'] ) {
+      removeContainer($Name);
+    }
     execCommand($cmd);
     $DockerClient->flushCaches();
     $newImageID = $DockerClient->getImageID($Repository);

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -176,7 +176,9 @@ if ($_GET['updateContainer']){
       stopContainer($Name);
     }
     // force kill container if still running after 10 seconds
-    removeContainer($Name);
+   	if ( ! $_GET['communityApplications'] ) {
+			removeContainer($Name);
+		}
     execCommand($cmd);
     $DockerClient->flushCaches();
     $newImageID = $DockerClient->getImageID($Repository);


### PR DESCRIPTION
CA currently when installing multiple previously installed apps will copy, modify, and execute a different version of CreateDocker.php to avoid a harmless display error.  Minor code adjustment to prevent CA from having to do that (since it may at some point in the future break).