### PR TITLE
Fix container log size

### DIFF
--- a/plugins/dynamix.docker.manager/include/GetContainerSize.php
+++ b/plugins/dynamix.docker.manager/include/GetContainerSize.php
@@ -40,7 +40,7 @@ foreach ($container as $ct) {
   list($name,$size) = explode('|',$ct);
   list($writable,$dummy,$total) = explode(' ',str_replace(['(',')'],'',$size));
   list($value,$base) = explode(' ',gap($total));
-  $list[] = ['name' => $name, 'total' => $value*pow(1000,array_search($base,$unit)), 'writable' => $writable, 'log' => exec("docker logs $name 2>/dev/null|wc -c")];
+  $list[] = ['name' => $name, 'total' => $value*pow(1000,array_search($base,$unit)), 'writable' => $writable, 'log' => exec("docker logs $name 2>&1|wc -c")];
 }
 array_multisort(array_column($list,'total'),SORT_DESC,$list); // sort on container size
 foreach ($list as $ct) echo align($ct['name'],-30).align(autoscale($ct['total'])).align($ct['writable']).align(autoscale($ct['log']))."\n";


### PR DESCRIPTION
The docker logs command outputs to both stdout and stderr depending upon the type of log entry.  Both have to be accounting for in determining the log size

> I (shamelessly) took the part from Squid's script to include log file sizes.

Looks like you missed that bit in my code bonienl  :)  