### PR TITLE
Fix/Update default-white template for smaller screens

### DIFF
--- a/plugins/dynamix/styles/default-azure.css
+++ b/plugins/dynamix/styles/default-azure.css
@@ -1,6 +1,6 @@
 html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#e4e2e4;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-@media (max-width:1280px){#template{min-width:1280px;margin:0}}
+@media (max-width:1280px){#template{min-width:940px;margin:0}}
 @media (min-width:1281px){#template{min-width:1280px;margin:0}}
 @media (min-width:1921px){#template{min-width:1280px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -1,6 +1,6 @@
 html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#f2f2f2;background-color:#1c1b1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-@media (max-width:1280px){#template{min-width:1280px;margin:0}}
+@media (max-width:1280px){#template{min-width:940px;margin:0}}
 @media (min-width:1281px){#template{min-width:1280px;margin:0 10px}}
 @media (min-width:1921px){#template{min-width:1280px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}

--- a/plugins/dynamix/styles/default-gray.css
+++ b/plugins/dynamix/styles/default-gray.css
@@ -1,6 +1,6 @@
 html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#1b1d1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-@media (max-width:1280px){#template{min-width:1280px;margin:0}}
+@media (max-width:1280px){#template{min-width:940px;margin:0}}
 @media (min-width:1281px){#template{min-width:1280px;margin:0}}
 @media (min-width:1921px){#template{min-width:1280px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -1,6 +1,6 @@
 html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#1c1b1b;background-color:#f2f2f2;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
-@media (max-width:1280px){#template{min-width:1280px;margin:0}}
+@media (max-width:1280px){#template{min-width:940px;margin:0}}
 @media (min-width:1281px){#template{min-width:1280px;margin:0 10px}}
 @media (min-width:1921px){#template{min-width:1280px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}


### PR DESCRIPTION
This @media rule's min-width requires a minimum width that is not necessary since the website renders fine at 940px wide without any horizontal scrolling.  
  
With the min-width rule @ 1280px wide, I have monitors that don't display the table properly and also, some of us like to have unRaid open in a small window alongside other apps.  

![Before Change](https://i.imgur.com/52hFIsE.png)  
  


![After Change](https://i.imgur.com/kgfxlXw.png)
