### PR TITLE
Suppress PHP error under certain circumstances if plugin does not have an icon

### DIFF
--- a/plugins/dynamix.plugin.manager/include/PluginHelpers.php
+++ b/plugins/dynamix.plugin.manager/include/PluginHelpers.php
@@ -49,7 +49,7 @@ function icon($name) {
 // try alternatives if default is not present
   $icon = "plugins/$name/$name.png";
   if (file_exists($icon)) return $icon;
-  $image = preg_split('/[\._- ]/',$name)[0];
+  $image = @preg_split('/[\._- ]/',$name)[0];
   $icon = "plugins/$name/images/$image.png";
   if (file_exists($icon)) return $icon;
   $icon = "plugins/$name/$image.png";


### PR DESCRIPTION
Under certain circumstances, a valid plugin without a determinable icon will return

Warning: preg_split(): Compilation failed: range out of order in character class at offset 5 in /usr/local/emhttp/plugins/dynamix.plugin.manager/include/PluginHelpers.php on line 52

Suppress it