### PR TITLE
Preserve \n on  docker templates between advanced and basic view

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1192,7 +1192,7 @@ button[type=button]{margin:0 20px 0 0}
   }
   function load_contOverview() {
     var new_overview = $("textarea[name='contOverview']").val();
-		new_overview = new_overview.replaceAll("\n","[br]");
+    new_overview = new_overview.replaceAll("\n","[br]");
     new_overview = new_overview.replaceAll("[","<").replaceAll("]",">");
 
     $("#contDescription").html(new_overview);

--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -1192,7 +1192,9 @@ button[type=button]{margin:0 20px 0 0}
   }
   function load_contOverview() {
     var new_overview = $("textarea[name='contOverview']").val();
+		new_overview = new_overview.replaceAll("\n","[br]");
     new_overview = new_overview.replaceAll("[","<").replaceAll("]",">");
+
     $("#contDescription").html(new_overview);
   }
   $(function() {


### PR DESCRIPTION
Preserves newlines between Advanced View and Basic View when creating / editing a template, without having an author resort to using [br] in the overview.

Compare installing "Mopidy" (Advanced vs Basic) before and after this PR