### PR TITLE
Docker: Add More Info link (docker registry) to context menus

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -57,7 +57,8 @@ foreach ($containers as $ct) {
   $webGui = html_entity_decode($info['url']);
   $support = html_entity_decode($info['Support']);
   $project = html_entity_decode($info['Project']);
-  $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project));
+  $registry = html_entity_decode($info['registry']);
+  $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project),addslashes($registry));
   $docker[] = "docker.push({name:'$name',id:'$id',state:$running,pause:$paused,update:'$updateStatus'});";
   $shape = $running ? ($paused ? 'pause' : 'play') : 'square';
   $status = $running ? ($paused ? 'paused' : 'started') : 'stopped';

--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -57,7 +57,7 @@ foreach ($containers as $ct) {
   $webGui = html_entity_decode($info['url']);
   $support = html_entity_decode($info['Support']);
   $project = html_entity_decode($info['Project']);
-  $registry = html_entity_decode($info['Registry']);
+  $registry = html_entity_decode($info['registry']);
   $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project),addslashes($registry));
   $docker[] = "docker.push({name:'$name',id:'$id',state:$running,pause:$paused,update:'$updateStatus'});";
   $shape = $running ? ($paused ? 'pause' : 'play') : 'square';

--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -57,7 +57,7 @@ foreach ($containers as $ct) {
   $webGui = html_entity_decode($info['url']);
   $support = html_entity_decode($info['Support']);
   $project = html_entity_decode($info['Project']);
-  $registry = html_entity_decode($info['registry']);
+  $registry = html_entity_decode($info['Registry']);
   $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project),addslashes($registry));
   $docker[] = "docker.push({name:'$name',id:'$id',state:$running,pause:$paused,update:'$updateStatus'});";
   $shape = $running ? ($paused ? 'pause' : 'play') : 'square';

--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -1,6 +1,6 @@
 var eventURL = '/plugins/dynamix.docker.manager/include/Events.php';
 
-function addDockerContainerContext(container, image, template, started, paused, update, autostart, webui, shell, id, Support, Project) {
+function addDockerContainerContext(container, image, template, started, paused, update, autostart, webui, shell, id, Support, Project, Registry) {
   var opts = [{header:container, image:'/plugins/dynamix.docker.manager/images/dynamix.docker.manager.png'}];
   if (started && !paused) {
     if (webui !== '' && webui != '#') opts.push({text:'WebUI', icon:'fa-globe', href:webui, target:'_blank'});
@@ -37,6 +37,9 @@ function addDockerContainerContext(container, image, template, started, paused, 
   }
   if (Project) {
     opts.push({text:'Project Page', icon:'fa-life-ring', href:Project, target:'_blank'});
+  }
+  if (Registry) {
+    opts.push({text:'More Info',icon:'fa-info-circle', href:Registry, target:'_blank'});
   }
   context.attach('#'+id, opts);
 }

--- a/plugins/dynamix/include/DashboardApps.php
+++ b/plugins/dynamix/include/DashboardApps.php
@@ -44,7 +44,8 @@ if ($_POST['docker'] && ($display=='icons' || $display=='docker')) {
     $webGui = html_entity_decode($info['url']);
     $support = html_entity_decode($info['Support']);
     $project = html_entity_decode($info['Project']);
-    $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project));
+    $registry = html_entity_decode($info['registry']);
+    $menu[] = sprintf("addDockerContainerContext('%s','%s','%s',%s,%s,%s,%s,'%s','%s','%s','%s','%s','%s');", addslashes($name), addslashes($ct['ImageId']), addslashes($template), $running, $paused, $updateStatus, $is_autostart, addslashes($webGui), $shell, $id, addslashes($support), addslashes($project), addslashes($registry));
     $shape = $running ? ($paused ? 'pause' : 'play') : 'square';
     $status = $running ? ($paused ? 'paused' : 'started') : 'stopped';
     $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');


### PR DESCRIPTION
Because more and more maintainers don't include in the support thread enough info to configure the container, but rather include on the registry page