### PR TITLE
Fix plugin download routine

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -149,7 +149,7 @@ EOF;
 // Returns TRUE if success else FALSE and fills in error.
 //
 function download($URL, $name, &$error) {
-  if ($file = popen("wget --compressed=auto --no-cache --progress=dot -O $name $URL 2>&1", 'r')) {
+  if ($file = popen("wget --compression=auto --no-cache --progress=dot -O $name $URL 2>&1", 'r')) {
     echo "plugin: downloading: $URL ...\r";
     $level = -1;
     while (!feof($file)) {


### PR DESCRIPTION
Fatal typo in my original PR #473 that prevents any plugin ( or a subsequent OS update ) from installing.  My bad -> happened because I was too lazy to merge into my fork the tested code and simply manually did a patch.