### PR TITLE
Add Elapsed Time and increments columns to Parity History

### DIFF
--- a/plugins/dynamix/include/ParityHistory.php
+++ b/plugins/dynamix/include/ParityHistory.php
@@ -37,16 +37,17 @@ function his_duration($time) {
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 </head>
 <body>
-<table class='share_status'><thead><tr><td>Date</td><td>Duration</td><td>Speed</td><td>Status</td><td>Errors</td></tr></thead><tbody>
+<table class='share_status'><thead><tr><td>Date</td><td>Duration<td>Elapsed</td><td>Speed</td><td>Status</td><td>Errors</td>
+<td>Increments</td></tr></thead><tbody>
 <?
 $log = '/boot/config/parity-checks.log'; $list = [];
 if (file_exists($log)) {
   $handle = fopen($log, 'r');
   while (($line = fgets($handle)) !== false) {
-    list($date,$duration,$speed,$status,$error) = explode('|',$line);
+    list($date,$duration,$speed,$status,$error,$elapsed,$increments) = explode('|',$line);
     if ($speed==0) $speed = 'Unavailable';
     $date = str_replace(' ',', ',strtr(str_replace('  ',' 0',$date),$month));
-    if ($duration>0||$status<>0) $list[] = "<tr><td>$date</td><td>".his_duration($duration)."</td><td>$speed</td><td>".($status==0?'OK':($status==-4?'Canceled':$status))."</td><td>$error</td></tr>";
+    if ($duration>0||$status<>0) $list[] = "<tr><td>$date</td><td>".his_duration($duration)."</td><td>".($elapsed==0?'Unknown':his_duration($elapsed))."</td><td>$speed</td><td>".($status==0?'OK':($status==-4?'Canceled':$status))."</td><td>$error</td><td>".($increments==0?'Unknown':$increments)."<td></td></tr>";
   }
   fclose($handle);
 }


### PR DESCRIPTION
Adds two new columns to the Parity History report (Elapsed and Increments).   On the default Unraid system these will be displayed as 'Unknown'    If the Parity Check Tuning plugin is installed then there will be values displayed in these new columns when relevant.