### PR TITLE
Don't allow plugin updates to same version

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -624,6 +624,11 @@ if ($method == "update") {
     echo "plugin: installed Unraid version is too high, require at most version $max\n";
     exit(1);
   }
+  // check for a reinstall of same version
+  if (strcmp(plugin("version",$installed_plugin_file,$error),plugin("version",$plugin_file,$error1)) == 0) {
+    echo "Not reinstalling same version\n";
+    exit(1);
+  }
   // install the updated plugin
   if (plugin("install", $plugin_file, $error) === false) {
     echo "plugin: $error\n";


### PR DESCRIPTION
Should solve the odd problem with CA where updates effectively remove the plugin, due to user clicking the CA link to update itself, but auto update (eg) has already updated the plugin (ie: auto update updated it while the CA page was open)