### PR TITLE
Allow redefineable showUpgrade / hideUpgrade functions

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -210,7 +210,7 @@ function showFooter(data, id) {
 function showNotice(data) {
   $('#user-notice').html(data.replace(/<a>(.*)<\/a>/,"<a href='/Plugins'>$1</a>"));
 }
-var showUpgrade = funtion(data) {
+var showUpgrade = function(data) {
   if ($.cookie('os_upgrade')==null)
     $('.upgrade_notice').html(data.replace(/<a>(.*)<\/a>/,"<a href='#' onclick='hideUpgrade();openUpgrade()'>$1</a>")+"<i class='fa fa-close' title='Close' onclick='hideUpgrade(true)'></i>").show();
 }

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -210,11 +210,11 @@ function showFooter(data, id) {
 function showNotice(data) {
   $('#user-notice').html(data.replace(/<a>(.*)<\/a>/,"<a href='/Plugins'>$1</a>"));
 }
-function showUpgrade(data) {
+var showUpgrade = funtion(data) {
   if ($.cookie('os_upgrade')==null)
     $('.upgrade_notice').html(data.replace(/<a>(.*)<\/a>/,"<a href='#' onclick='hideUpgrade();openUpgrade()'>$1</a>")+"<i class='fa fa-close' title='Close' onclick='hideUpgrade(true)'></i>").show();
 }
-function hideUpgrade(set) {
+var hideUpgrade = function(set) {
   $('.upgrade_notice').hide();
   if (set)
     $.cookie('os_upgrade','true',{path:'/'});


### PR DESCRIPTION
May seem like a rather strange PR, but CA has been working towards redefining the entire banner notification system (and opening it up to 3rd party apps, including CA).   

The hold-back on this currently is that on the Apps page which is making extensive use of the banner notification bar, any OS update notification is lost and won't be displayed. 

Allow CA to redefine those 2 functions to allow CA (and other 3rd Party Apps) to also utilize the banner without losing the OS upgrade notification.

Too see my vision, disable the docker service AND cookies in your browser and go to the apps tab. (ideally have CA up to date also and watch it for 20 seconds+)

See also this  https://forums.unraid.net/topic/79010-ca-api-for-plugin-update-checks/ for rev 1 of what CA's officially released and documented