### PR TITLE
Revamp Banner Warning System

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -220,59 +220,59 @@ var bannerWarningInterval = false;
 var osUpgradeWarning = false;
 
 function addBannerWarning(text,warning=true,noDismiss=false) {
-	var cookieText = text.replace(/[^a-z0-9]/gi,'');
-	if ( $.cookie(cookieText) == "true" ) { return false; }
-	
-	if ( warning ) {
-		text = "<i class='fa fa-warning' style='float:initial;'></i> "+text;
-	}
-	var arrayEntry = bannerWarnings.push("placeholder") - 1;
-	if ( ! noDismiss ) {
-		text = text + "<a class='bannerDismiss' onclick='dismissBannerWarning("+arrayEntry+",&quot;"+cookieText+"&quot;)'></a>";
-	}
-	bannerWarnings[arrayEntry] = text;
-	if ( ! bannerWarningInterval ) {
-		showBannerWarnings();
-		bannerWarningInterval = setInterval(function() {
-			showBannerWarnings()
-		},10000);
-	}
-	return arrayEntry;
+  var cookieText = text.replace(/[^a-z0-9]/gi,'');
+  if ( $.cookie(cookieText) == "true" ) { return false; }
+  
+  if ( warning ) {
+    text = "<i class='fa fa-warning' style='float:initial;'></i> "+text;
+  }
+  var arrayEntry = bannerWarnings.push("placeholder") - 1;
+  if ( ! noDismiss ) {
+    text = text + "<a class='bannerDismiss' onclick='dismissBannerWarning("+arrayEntry+",&quot;"+cookieText+"&quot;)'></a>";
+  }
+  bannerWarnings[arrayEntry] = text;
+  if ( ! bannerWarningInterval ) {
+    showBannerWarnings();
+    bannerWarningInterval = setInterval(function() {
+      showBannerWarnings()
+    },10000);
+  }
+  return arrayEntry;
 }
 
 function dismissBannerWarning(entry,cookieText) {
-	$.cookie(cookieText,"true");
-	removeBannerWarning(entry);
+  $.cookie(cookieText,"true");
+  removeBannerWarning(entry);
 }
 
 function removeBannerWarning(entry) {
-	bannerWarnings[entry] = false;
-	showBannerWarnings();
+  bannerWarnings[entry] = false;
+  showBannerWarnings();
 }
 
 function bannerFilterArray(array) {
-	var newArray = [];
-	array.filter(function(value,index,arr) {
-		if ( value ) {
-			newArray.push(value);
-		}
-	}); 
-	return newArray;
+  var newArray = [];
+  array.filter(function(value,index,arr) {
+    if ( value ) {
+      newArray.push(value);
+    }
+  }); 
+  return newArray;
 }
 
 function showBannerWarnings() {
-	var allWarnings = bannerFilterArray(Object.values(bannerWarnings));
-	if ( allWarnings.length == 0 ) {
-		$(".upgrade_notice").hide();
-		clearInterval(bannerWarningInterval);
-		bannerWarningInterval = false;
-		return;
-	}
-	if ( currentBannerWarning >= allWarnings.length ) {
-		currentBannerWarning = 0;
-	}
-	$(".upgrade_notice").show().html(allWarnings[currentBannerWarning]);
-	currentBannerWarning++;
+  var allWarnings = bannerFilterArray(Object.values(bannerWarnings));
+  if ( allWarnings.length == 0 ) {
+    $(".upgrade_notice").hide();
+    clearInterval(bannerWarningInterval);
+    bannerWarningInterval = false;
+    return;
+  }
+  if ( currentBannerWarning >= allWarnings.length ) {
+    currentBannerWarning = 0;
+  }
+  $(".upgrade_notice").show().html(allWarnings[currentBannerWarning]);
+  currentBannerWarning++;
 }
 
 function showUpgrade(data,noDismiss=false) {

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -212,83 +212,75 @@ function showNotice(data) {
   $('#user-notice').html(data.replace(/<a>(.*)<\/a>/,"<a href='/Plugins'>$1</a>"));
 }
 
+// Banner warning system
 
-	var bannerWarnings = [];
-	var currentBannerWarning = 0;
-	var bannerWarningInterval = false;
-	var osUpgradeWarning = false;
+var bannerWarnings = [];
+var currentBannerWarning = 0;
+var bannerWarningInterval = false;
+var osUpgradeWarning = false;
 
-
-	function addBannerWarning(text,warning=true,noDismiss=false) {
-		var cookieText = text.replace(/[^a-z0-9]/gi,'');
-		if ( $.cookie(cookieText) == "true" ) { return false; }
-		
-		if ( warning ) {
-			text = "<i class='fa fa-warning' style='float:initial;'></i> "+text;
-		}
-		var arrayEntry = bannerWarnings.push("placeholder") - 1;
-		if ( ! noDismiss ) {
-			text = text + "<a class='bannerDismiss' onclick='dismissBannerWarning("+arrayEntry+",&quot;"+cookieText+"&quot;)'></a>";
-		}
-		console.log(text);
-		bannerWarnings[arrayEntry] = text;
-		if ( ! bannerWarningInterval ) {
-			showBannerWarnings();
- 			bannerWarningInterval = setInterval(function() {
-				showBannerWarnings()
-			},10000);
-		}
-		return arrayEntry;
+function addBannerWarning(text,warning=true,noDismiss=false) {
+	var cookieText = text.replace(/[^a-z0-9]/gi,'');
+	if ( $.cookie(cookieText) == "true" ) { return false; }
+	
+	if ( warning ) {
+		text = "<i class='fa fa-warning' style='float:initial;'></i> "+text;
 	}
-
-	function dismissBannerWarning(entry,cookieText) {
-		$.cookie(cookieText,"true");
-		removeBannerWarning(entry);
+	var arrayEntry = bannerWarnings.push("placeholder") - 1;
+	if ( ! noDismiss ) {
+		text = text + "<a class='bannerDismiss' onclick='dismissBannerWarning("+arrayEntry+",&quot;"+cookieText+"&quot;)'></a>";
 	}
-
-	function removeBannerWarning(entry) {
-		bannerWarnings[entry] = false;
+	bannerWarnings[arrayEntry] = text;
+	if ( ! bannerWarningInterval ) {
 		showBannerWarnings();
+		bannerWarningInterval = setInterval(function() {
+			showBannerWarnings()
+		},10000);
 	}
+	return arrayEntry;
+}
 
-	function bannerFilterArray(array) {
-		var newArray = [];
-		array.filter(function(value,index,arr) {
-			if ( value ) {
-				newArray.push(value);
-			}
-		});	
-		return newArray;
-	}
+function dismissBannerWarning(entry,cookieText) {
+	$.cookie(cookieText,"true");
+	removeBannerWarning(entry);
+}
 
-	function showBannerWarnings() {
-		var allWarnings = bannerFilterArray(Object.values(bannerWarnings));
-		if ( allWarnings.length == 0 ) {
-			$(".upgrade_notice").hide();
-			clearInterval(bannerWarningInterval);
-			bannerWarningInterval = false;
-			return;
+function removeBannerWarning(entry) {
+	bannerWarnings[entry] = false;
+	showBannerWarnings();
+}
+
+function bannerFilterArray(array) {
+	var newArray = [];
+	array.filter(function(value,index,arr) {
+		if ( value ) {
+			newArray.push(value);
 		}
-		if ( currentBannerWarning >= allWarnings.length ) {
-			currentBannerWarning = 0;
-		}
-		$(".upgrade_notice").show().html(allWarnings[currentBannerWarning]);
-		currentBannerWarning++;
+	}); 
+	return newArray;
+}
+
+function showBannerWarnings() {
+	var allWarnings = bannerFilterArray(Object.values(bannerWarnings));
+	if ( allWarnings.length == 0 ) {
+		$(".upgrade_notice").hide();
+		clearInterval(bannerWarningInterval);
+		bannerWarningInterval = false;
+		return;
 	}
-
-
-
-
-
-
-
+	if ( currentBannerWarning >= allWarnings.length ) {
+		currentBannerWarning = 0;
+	}
+	$(".upgrade_notice").show().html(allWarnings[currentBannerWarning]);
+	currentBannerWarning++;
+}
 
 function showUpgrade(data,noDismiss=false) {
   if ($.cookie('os_upgrade')==null) {
-		if (osUpgradeWarning)
-			removeBannerWarning(osUpgradeWarning);
-		osUpgradeWarning = addBannerWarning(data.replace(/<a>(.*)<\/a>/,"<a href='#' onclick='hideUpgrade();openUpgrade();'>$1</a>"),false,noDismiss);
-	}
+    if (osUpgradeWarning)
+      removeBannerWarning(osUpgradeWarning);
+    osUpgradeWarning = addBannerWarning(data.replace(/<a>(.*)<\/a>/,"<a href='#' onclick='hideUpgrade();openUpgrade();'>$1</a>"),false,noDismiss);
+  }
 }
 function hideUpgrade(set) {
   removeBannerWarning(osUpgradeWarning);
@@ -298,7 +290,6 @@ function hideUpgrade(set) {
     $.removeCookie('os_upgrade',{path:'/'});
 }
 function openUpgrade() {
-	console.log("got here");
   swal({title:'Update Unraid OS',text:'Do you want to update to the new version?',type:'warning',showCancelButton:true},function(){
     openBox('/plugins/dynamix.plugin.manager/scripts/plugin&arg1=update&arg2=unRAIDServer.plg','Update Unraid OS',600,900,true);
   });

--- a/plugins/dynamix/styles/default-azure.css
+++ b/plugins/dynamix/styles/default-azure.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#e4e2e4;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0}}
-@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:left}
 p.centered{text-align:left}
@@ -53,7 +53,7 @@ textarea{resize:none}
 #header .text-right{float:right;text-align:left;padding-left:5px}
 #header .text-right a{color:#606e7f}
 #header .text-right #licensetype{font-weight:bold;font-style:italic;margin-right:4px}
-#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:2000;box-shadow:inset -1px 0 2px #edeaef}
+#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:100;box-shadow:inset -1px 0 2px #edeaef}
 #nav-block{position:absolute;top:0;bottom:12px;color:#ffdfb9;white-space:nowrap;float:left;overflow-y:scroll;direction:rtl;letter-spacing:1.8px}
 #nav-block::-webkit-scrollbar{display:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}
@@ -335,3 +335,7 @@ span.checkmark{position:absolute;top:0;left:6px;height:14px;width:14px;backgroun
 label.checkbox:hover input ~ .checkmark{background-color:#a4a2a4}
 label.checkbox input:checked ~ .checkmark{background-color:#ff8c2f}
 label.checkbox input:disabled ~ .checkmark{opacity:0.5}
+a.bannerDismiss {float:right;cursor:pointer;text-decoration:none;margin-right:1rem;}
+.bannerDismiss::before {content:"\e92f";font-family:Unraid;color:#e68a00;}
+a.bannerInfo {cursor:pointer;text-decoration:none;}
+.bannerInfo::before {content:"\f05a";font-family:fontAwesome;color:#e68a00;}

--- a/plugins/dynamix/styles/default-azure.css
+++ b/plugins/dynamix/styles/default-azure.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#e4e2e4;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0}}
-@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:left}
 p.centered{text-align:left}
@@ -53,7 +53,7 @@ textarea{resize:none}
 #header .text-right{float:right;text-align:left;padding-left:5px}
 #header .text-right a{color:#606e7f}
 #header .text-right #licensetype{font-weight:bold;font-style:italic;margin-right:4px}
-#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:100;box-shadow:inset -1px 0 2px #edeaef}
+#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:2000;box-shadow:inset -1px 0 2px #edeaef}
 #nav-block{position:absolute;top:0;bottom:12px;color:#ffdfb9;white-space:nowrap;float:left;overflow-y:scroll;direction:rtl;letter-spacing:1.8px}
 #nav-block::-webkit-scrollbar{display:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#f2f2f2;background-color:#1c1b1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0 10px}}
-@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:justify}
 p.centered{text-align:left}

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#f2f2f2;background-color:#1c1b1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0 10px}}
-@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:justify}
 p.centered{text-align:left}
@@ -314,3 +314,7 @@ span.checkmark{position:absolute;top:0;left:6px;height:14px;width:14px;backgroun
 label.checkbox:hover input ~ .checkmark{background-color:#5b5b5b}
 label.checkbox input:checked ~ .checkmark{background-color:#ff8c2f}
 label.checkbox input:disabled ~ .checkmark{opacity:0.5}
+a.bannerDismiss {float:right;cursor:pointer;text-decoration:none;margin-right:1rem;}
+.bannerDismiss::before {content:"\e92f";font-family:Unraid;color:#e68a00;}
+a.bannerInfo {cursor:pointer;text-decoration:none;}
+.bannerInfo::before {content:"\f05a";font-family:fontAwesome;color:#e68a00;}

--- a/plugins/dynamix/styles/default-gray.css
+++ b/plugins/dynamix/styles/default-gray.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#1b1d1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0}}
-@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:left}
 p.centered{text-align:left}
@@ -53,7 +53,7 @@ textarea{resize:none}
 #header .text-right{float:right;text-align:left;padding-left:5px}
 #header .text-right a{color:#606e7f}
 #header .text-right #licensetype{font-weight:bold;font-style:italic;margin-right:4px}
-#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:100;box-shadow:inset -1px 0 2px #121510}
+#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:2000;box-shadow:inset -1px 0 2px #121510}
 #nav-block{position:absolute;top:0;bottom:12px;color:#ffdfb9;white-space:nowrap;float:left;overflow-y:scroll;direction:rtl;letter-spacing:1.8px}
 #nav-block::-webkit-scrollbar{display:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}

--- a/plugins/dynamix/styles/default-gray.css
+++ b/plugins/dynamix/styles/default-gray.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#606e7f;background-color:#1b1d1b;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0}}
-@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:left}
 p.centered{text-align:left}
@@ -53,7 +53,7 @@ textarea{resize:none}
 #header .text-right{float:right;text-align:left;padding-left:5px}
 #header .text-right a{color:#606e7f}
 #header .text-right #licensetype{font-weight:bold;font-style:italic;margin-right:4px}
-#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:2000;box-shadow:inset -1px 0 2px #121510}
+#menu{position:fixed;top:0;left:0;bottom:12px;width:65px;padding:0;margin:0;background-color:#383a34;z-index:100;box-shadow:inset -1px 0 2px #121510}
 #nav-block{position:absolute;top:0;bottom:12px;color:#ffdfb9;white-space:nowrap;float:left;overflow-y:scroll;direction:rtl;letter-spacing:1.8px}
 #nav-block::-webkit-scrollbar{display:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}
@@ -335,3 +335,7 @@ span.checkmark{position:absolute;top:0;left:6px;height:14px;width:14px;backgroun
 label.checkbox:hover input ~ .checkmark{background-color:#5b5d5b}
 label.checkbox input:checked ~ .checkmark{background-color:#ff8c2f}
 label.checkbox input:disabled ~ .checkmark{opacity:0.5}
+a.bannerDismiss {float:right;cursor:pointer;text-decoration:none;margin-right:1rem;}
+.bannerDismiss::before {content:"\e92f";font-family:Unraid;color:#e68a00;}
+a.bannerInfo {cursor:pointer;text-decoration:none;}
+.bannerInfo::before {content:"\f05a";font-family:fontAwesome;color:#e68a00;}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#1c1b1b;background-color:#f2f2f2;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0 10px}}
-@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:justify}
 p.centered{text-align:left}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -2,7 +2,7 @@ html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#1c1b1b;background-color:#f2f2f2;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
 @media (max-width:1280px){#template{min-width:1260px;max-width:1260px;margin:0}}
 @media (min-width:1281px){#template{min-width:1260px;margin:0 10px}}
-@media (min-width:1921px){#template{min-width:1260px;max-width:1920px;margin:0 auto}}
+@media (min-width:1921px){#template{min-width:1260px;margin:0 auto}}
 img{border:none;text-decoration:none;vertical-align:middle}
 p{text-align:justify}
 p.centered{text-align:left}
@@ -314,3 +314,7 @@ span.checkmark{position:absolute;top:0;left:6px;height:14px;width:14px;backgroun
 label.checkbox:hover input ~ .checkmark{background-color:#b3b3b3}
 label.checkbox input:checked ~ .checkmark{background-color:#ff8c2f}
 label.checkbox input:disabled ~ .checkmark{opacity:0.5}
+a.bannerDismiss {float:right;cursor:pointer;text-decoration:none;margin-right:1rem;}
+.bannerDismiss::before {content:"\e92f";font-family:Unraid;color:#e68a00;}
+a.bannerInfo {cursor:pointer;text-decoration:none;}
+.bannerInfo::before {content:"\f05a";font-family:fontAwesome;color:#e68a00;}


### PR DESCRIPTION
A number of advantages

- From my point of view, the most important is that it opens up the banner warning to 3rd party plugins, without CA's function having to create its banners with a z-index greater than the OS update z-index
- Allows multiple banner warnings ( browser will cycle through them ) (Previously, System Notifications Disabled couldn't be displayed if an OS or Reboot Warning was present ) (If desired, ACS Override can now via suitable programming toss up a reboot now banner instead of only appearing on its own page)
- If user dismisses an OS update, if another becomes available, then the banner will re-appear unlike previous operation if the browser window was not closed.
- Any given warning is able to be dismissed without any programming
- Warnings are able to be removed by the OS / plugin itself if the circumstances that result in it being displayed are no longer present