### PR TITLE
enable group chat IDs, update helper description

### DIFF
--- a/plugins/dynamix/include/NotificationAgents.xml
+++ b/plugins/dynamix/include/NotificationAgents.xml
@@ -215,9 +215,10 @@
     <Variables>
       <Variable Help="[a href='https://telegram.me/botfather' target='_blank'][u]BotFather[/u][/a] is the one bot to rule them all.[br][br]
         1. Make a bot using BotFather[br]
-        2. Paste bot token in this field[br]
-        3. Select bot via Telegram and press /start[br]
-        4. Test bot (first test will be slow)[/a]" Desc="Bot Access Token" Default="">BOT_TOKEN</Variable>
+        2. Paste the bot token in this field[br]
+        3. Message the bot via Telegram (either via a direct message or a message via a group)[br]
+        4. Test the bot[br][br]
+        * To reset the notifications receiving user or group, run [i]rm /boot/config/plugins/dynamix/telegram/chatid[/i] in the terminal and re-run steps 3. and 4.[/a]" Desc="Bot Access Token" Default="">BOT_TOKEN</Variable>
       <Variable Help="Specify the fields which are included in the title of the notification." Desc="Notification Title" Default="$SUBJECT">TITLE</Variable>
       <Variable Help="Specify the fields which are included in the message body of the notification." Desc="Notification Message" Default="$DESCRIPTION">MESSAGE</Variable>
     </Variables>
@@ -242,7 +243,7 @@
       if [[ ! -f $TELEGRAM/chatid || "$STORED_TOKEN" != "$BOT_TOKEN" ]]; then
         mkdir -p $TELEGRAM;
         LASTCHATID=$(curl -s https://api.telegram.org/bot$BOT_TOKEN/getUpdates | jq ".result | last .message .chat .id");
-        [[ $LASTCHATID =~ ^[0-9]+$ ]] && echo $LASTCHATID > $TELEGRAM/chatid || exit 1
+        [[ $LASTCHATID =~ ^-*[0-9]+$ ]] && echo $LASTCHATID > $TELEGRAM/chatid || exit 1
       fi
 
       CHATID=$(< $TELEGRAM/chatid);


### PR DESCRIPTION
A discussion in the unRAID Telegram group has revealed that adding the notifications receiving Telegram bot to a group chat does not work as group chat IDs start with a negative sign and the current regex does not account for that, this PR should fix it.

There's also the suggestion from a user that we expose the chat ID as a text field to the notification agent settings, although I am having the concern that this might confuse users that are not that familiar with the Telegram API and am leaning towards the automatic chat ID fetching. Thoughts?