### PR TITLE
Only create session when user successfully logs in

### DIFF
--- a/auth_request.php
+++ b/auth_request.php
@@ -1,18 +1,18 @@
 <?php
-session_name("unraid_".md5(strstr($_SERVER['HTTP_HOST'].':', ':', true)));
-session_set_cookie_params(0, '/; samesite=strict', null, array_key_exists('HTTPS', $_SERVER), true);
-session_start();
-
-// authorized
-if (isset($_SESSION["unraid_login"])) {
-  if (time() - $_SESSION['unraid_login'] > 300) {
-    $_SESSION['unraid_login'] = time();
+// only start the session if a session cookie exists
+if (isset($_COOKIE[session_name()])) {
+  session_start();
+  // authorized?
+  if (isset($_SESSION["unraid_login"])) {
+    if (time() - $_SESSION['unraid_login'] > 300) {
+      $_SESSION['unraid_login'] = time();
+    }
+    session_write_close();
+    http_response_code(200);
+    exit;
   }
   session_write_close();
-  http_response_code(200);
-  exit;
 }
-session_write_close();
 
 $arrWhitelist = [
   '/webGui/styles/clear-sans-bold-italic.eot',

--- a/login.php
+++ b/login.php
@@ -9,6 +9,8 @@ if ($_SERVER['REQUEST_URI'] == '/logout') {
     // User Logout
     if (isset($_COOKIE[session_name()])) {
         session_start();
+        unset($_SESSION['unraid_login']);
+        unset($_SESSION['unraid_user']);
         // delete session file
         session_destroy();
         // delete the session cookie

--- a/plugins/dynamix/include/local_prepend.php
+++ b/plugins/dynamix/include/local_prepend.php
@@ -22,6 +22,9 @@ putenv('PATH=.:/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin');
 chdir('/usr/local/emhttp');
 setlocale(LC_ALL,'en_US.UTF-8');
 date_default_timezone_set(substr(readlink('/etc/localtime-copied-from'),20));
+ini_set("session.use_strict_mode", "1");
+session_name("unraid_".md5(strstr($_SERVER['HTTP_HOST'].':', ':', true)));
+session_set_cookie_params(0, '/; samesite=strict', null, array_key_exists('HTTPS', $_SERVER), true);
 if ($_SERVER['SCRIPT_NAME'] != '/login.php' && $_SERVER['SCRIPT_NAME'] != '/auth_request.php' && isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!isset($var)) $var = parse_ini_file('state/var.ini');
     if (!isset($var['csrf_token'])) csrf_terminate("uninitialized");


### PR DESCRIPTION
Also, enable session.use_strict_mode to prevent session fixation attacks