### PR TITLE
Switch #nav-item to .nav-item

### DIFF
--- a/plugins/dynamix/HelpButton.page
+++ b/plugins/dynamix/HelpButton.page
@@ -17,7 +17,7 @@ Code="e934"
 ?>
 <script>
 function HelpButton() {
-  if ($('#nav-item.HelpButton').toggleClass('active').hasClass('active')) {
+  if ($('.nav-item.HelpButton').toggleClass('active').hasClass('active')) {
     $('.inline_help').show('slow');
     $.cookie('help','help',{path:'/'});
   } else {

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -50,8 +50,8 @@ html{font-size:<?=$display['font']?>}
 #header{background-color:#<?=$backgnd?>}
 <?if ($themes1):?>
 #menu{background-color:#<?=$backgnd?>}
-#nav-block #nav-item a{color:#<?=$header?>}
-#nav-block #nav-item.active:after{background-color:#<?=$header?>}
+#nav-block .nav-item a{color:#<?=$header?>}
+#nav-block .nav-item.active:after{background-color:#<?=$header?>}
 <?endif;?>
 <?endif;?>
 .inline_help{display:none}
@@ -67,8 +67,8 @@ echo "#header.image{background-image:url(";
 echo file_exists($banner) ? autov($banner) : '/webGui/images/banner.png';
 echo ")}\n";
 if ($themes2) {
-  foreach ($tasks as $button) if ($button['Code']) echo "#nav-item a[href='/{$button['name']}']:before{content:'\\{$button['Code']}'}\n";
-  foreach ($buttons as $button) if ($button['Code']) echo "#nav-item.{$button['name']} a:before{content:'\\{$button['Code']}'}\n";
+  foreach ($tasks as $button) if ($button['Code']) echo ".nav-item a[href='/{$button['name']}']:before{content:'\\{$button['Code']}'}\n";
+  foreach ($buttons as $button) if ($button['Code']) echo ".nav-item.{$button['name']} a:before{content:'\\{$button['Code']}'}\n";
 }
 $notes = '/var/tmp/unRAIDServer.txt';
 if (!file_exists($notes)) file_put_contents($notes,shell_exec("$docroot/plugins/dynamix.plugin.manager/scripts/plugin changes $docroot/plugins/unRAIDServer/unRAIDServer.plg"));
@@ -368,7 +368,7 @@ function viewHistory(filter) {
 $(function() {
   var tab = $.cookie('one')||$.cookie('tab')||'tab1';
   if (tab=='tab0') tab = 'tab'+$('input[name$="tabs"]').length; else if ($('#'+tab).length==0) {initab(); tab = 'tab1';}
-  if ($.cookie('help')=='help') {$('.inline_help').show(); $('#nav-item.HelpButton').addClass('active');}
+  if ($.cookie('help')=='help') {$('.inline_help').show(); $('.nav-item.HelpButton').addClass('active');}
   $('#'+tab).attr('checked', true);
   updateTime();
   $.jGrowl.defaults.closeTemplate = '<i class="fa fa-close"></i>';
@@ -411,17 +411,17 @@ $.ajaxPrefilter(function(s, orig, xhr){
   <a href="#" class="back_to_top" title="Back To Top"><i class="fa fa-arrow-circle-up"></i></a>
 <?
 // Build page menus
-echo "<div id='menu'><div id='nav-block'><div id='nav-left'>";
+echo '<div id="menu"><div id="nav-block"><div id="nav-left">';
 foreach ($tasks as $button) {
   $page = $button['name'];
-  echo "<div id='nav-item'";
+  echo '<div class="nav-item"';
   echo $task==$page ? " class='active'>" : ">";
   echo "<a href='/$page' onclick='initab()'>$page</a></div>";
 }
 unset($tasks);
 if ($display['usage']) my_usage();
 echo "</div>";
-echo "<div id='nav-right'>";
+echo '<div id="nav-right">';
 foreach ($buttons as $button) {
   eval("?>{$button['text']}");
   if (empty($button['Link'])) {
@@ -435,7 +435,7 @@ foreach ($buttons as $button) {
       $icon = "<i class='fa $icon system'></i>";
     }
     $title = $themes2 ? "" : " title='{$button['Title']}'";
-    echo "<div id='nav-item' class='{$button['name']} util'><a href='".($button['Href'] ?? '#')."' onclick='{$button['name']}();return false;'{$title}>$icon<span>{$button['Title']}</span></a></div>";
+    echo "<div class='nav-item {$button['name']} util'><a href='".($button['Href'] ?? '#')."' onclick='{$button['name']}();return false;'{$title}>$icon<span>{$button['Title']}</span></a></div>";
   } else
     echo "<div id='{$button['Link']}'></div>";
 }

--- a/plugins/dynamix/styles/default-azure.css
+++ b/plugins/dynamix/styles/default-azure.css
@@ -60,18 +60,18 @@ textarea{resize:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}
 #nav-block.mozilla{margin-left:-17px;overflow-y:scroll}
 #nav-block>div{direction:ltr}
-#nav-item{width:40px;text-align:left;padding:14px 24px 14px 0;border-bottom:1px solid #42453e;font-size:18px;overflow:hidden;transition:.2s background-color ease}
-#nav-item:hover{width:170px;color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);-webkit-transition:all 0.2s ease-in-out;transition:all 0.2s ease-in-out;border-bottom-color:#e22828}
-#nav-item:hover a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);border-bottom-color:#e22828}
-#nav-item img{display:none}
-#nav-item a{color:#a6a7a7;text-decoration:none;padding:19px 80px 12px 16px}
-#nav-item.util a{padding-left:24px}
-#nav-item a:before{font-family:docker-icon,fontawesome,unraid;font-size:26px;margin-right:25px}
-#nav-item.util a:before{font-size:16px}
-#nav-item.active,#nav-item.active a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f)}
-#nav-item.HelpButton.active:hover,#nav-item.HelpButton.active a:hover{background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);font-size:18px}
-#nav-item.HelpButton.active,#nav-item.HelpButton.active a{font-size:18px}
-#nav-item a i{display:none}
+.nav-item{width:40px;text-align:left;padding:14px 24px 14px 0;border-bottom:1px solid #42453e;font-size:18px;overflow:hidden;transition:.2s background-color ease}
+.nav-item:hover{width:170px;color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);-webkit-transition:all 0.2s ease-in-out;transition:all 0.2s ease-in-out;border-bottom-color:#e22828}
+.nav-item:hover a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);border-bottom-color:#e22828}
+.nav-item img{display:none}
+.nav-item a{color:#a6a7a7;text-decoration:none;padding:19px 80px 12px 16px}
+.nav-item.util a{padding-left:24px}
+.nav-item a:before{font-family:docker-icon,fontawesome,unraid;font-size:26px;margin-right:25px}
+.nav-item.util a:before{font-size:16px}
+.nav-item.active,.nav-item.active a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f)}
+.nav-item.HelpButton.active:hover,.nav-item.HelpButton.active a:hover{background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);font-size:18px}
+.nav-item.HelpButton.active,.nav-item.HelpButton.active a{font-size:18px}
+.nav-item a i{display:none}
 #nav-user{display:block;float:left;text-align:center;border:none}
 #nav-user.probe{font-size:1.1rem;margin-left:3px;margin-right:8px}
 #nav-tub1{position:fixed;top:56px;right:400px}

--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -62,17 +62,17 @@ textarea{resize:none}
 #nav-block{overflow:hidden;height:4rem;letter-spacing:1.8px}
 #nav-left{float:left}
 #nav-right{float:right}
-#nav-right #nav-item a{min-width:0}
-#nav-right #nav-item a span{display:none}
-#nav-block #nav-item,#nav-block #nav-user{float:left;display:block;text-align:center;margin:0}
-#nav-block #nav-item .system{vertical-align:middle;padding-bottom:2px;padding-right:4px}
+#nav-right .nav-item a{min-width:0}
+#nav-right .nav-item a span{display:none}
+#nav-block .nav-item,#nav-block #nav-user{float:left;display:block;text-align:center;margin:0}
+#nav-block .nav-item .system{vertical-align:middle;padding-bottom:2px;padding-right:4px}
 #nav-block #nav-user .probe{margin-left:3px;margin-right:8px}
-#nav-block #nav-item a{color:#1c1b1b;background-color:transparent;text-transform:uppercase;font-weight:bold;display:block;padding:0 10px}
-#nav-block #nav-item a{text-decoration:none;text-decoration-skip-ink:auto;-webkit-text-decoration-skip:objects;-webkit-transition:all .25s ease-out;transition:all .25s ease-out}
-#nav-block #nav-item{position:relative}
-#nav-block #nav-item:after{border-radius:4px;display:block;background-color:transparent;content:"";width:32px;height:2px;bottom:7px;position:absolute;left:50%;margin-left:-16px;-webkit-transition:all .25s ease-in-out;transition:all .25s ease-in-out;pointer-events:none}
-#nav-block #nav-item:focus:after,#nav-block #nav-item:hover:after{background-color:#f15a2c}
-#nav-block #nav-item.active:after{background-color:#1c1b1b}
+#nav-block .nav-item a{color:#1c1b1b;background-color:transparent;text-transform:uppercase;font-weight:bold;display:block;padding:0 10px}
+#nav-block .nav-item a{text-decoration:none;text-decoration-skip-ink:auto;-webkit-text-decoration-skip:objects;-webkit-transition:all .25s ease-out;transition:all .25s ease-out}
+#nav-block .nav-item{position:relative}
+#nav-block .nav-item:after{border-radius:4px;display:block;background-color:transparent;content:"";width:32px;height:2px;bottom:7px;position:absolute;left:50%;margin-left:-16px;-webkit-transition:all .25s ease-in-out;transition:all .25s ease-in-out;pointer-events:none}
+#nav-block .nav-item:focus:after,#nav-block .nav-item:hover:after{background-color:#f15a2c}
+#nav-block .nav-item.active:after{background-color:#1c1b1b}
 #txt-tub1,#txt-tub2,#txt-tub3{color:#f2f2f2}
 #clear{clear:both}
 #footer{position:fixed;bottom:0;left:0;color:#d4d5d6;background-color:#2b2a29;padding:5px 0;width:100%;height:1.6rem;line-height:1.6rem;text-align:center;z-index:10000}

--- a/plugins/dynamix/styles/default-gray.css
+++ b/plugins/dynamix/styles/default-gray.css
@@ -60,18 +60,18 @@ textarea{resize:none}
 #nav-block{-ms-overflow-style:none;overflow:-moz-scrollbars-none}
 #nav-block.mozilla{margin-left:-17px;overflow-y:scroll}
 #nav-block>div{direction:ltr}
-#nav-item{width:40px;text-align:left;padding:14px 24px 14px 0;border-bottom:1px solid #42453e;font-size:18px;overflow:hidden;transition:.2s background-color ease}
-#nav-item:hover{width:170px;color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);-webkit-transition:all 0.2s ease-in-out;transition:all 0.2s ease-in-out;border-bottom-color:#e22828}
-#nav-item:hover a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);border-bottom-color:#e22828}
-#nav-item img{display:none}
-#nav-item a{color:#a6a7a7;text-decoration:none;padding:19px 80px 12px 16px}
-#nav-item.util a{padding-left:24px}
-#nav-item a:before{font-family:docker-icon,fontawesome,unraid;font-size:26px;margin-right:25px}
-#nav-item.util a:before{font-size:16px}
-#nav-item.active,#nav-item.active a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f)}
-#nav-item.HelpButton.active:hover,#nav-item.HelpButton.active a:hover{background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);font-size:18px}
-#nav-item.HelpButton.active,#nav-item.HelpButton.active a{font-size:18px}
-#nav-item a i{display:none}
+.nav-item{width:40px;text-align:left;padding:14px 24px 14px 0;border-bottom:1px solid #42453e;font-size:18px;overflow:hidden;transition:.2s background-color ease}
+.nav-item:hover{width:170px;color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);-webkit-transition:all 0.2s ease-in-out;transition:all 0.2s ease-in-out;border-bottom-color:#e22828}
+.nav-item:hover a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);border-bottom-color:#e22828}
+.nav-item img{display:none}
+.nav-item a{color:#a6a7a7;text-decoration:none;padding:19px 80px 12px 16px}
+.nav-item.util a{padding-left:24px}
+.nav-item a:before{font-family:docker-icon,fontawesome,unraid;font-size:26px;margin-right:25px}
+.nav-item.util a:before{font-size:16px}
+.nav-item.active,.nav-item.active a{color:#ffdfb9;background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f)}
+.nav-item.HelpButton.active:hover,.nav-item.HelpButton.active a:hover{background:-webkit-gradient(linear,left top,right top,from(#e22828),to(#ff8c2f));background:linear-gradient(90deg,#e22828 0,#ff8c2f);font-size:18px}
+.nav-item.HelpButton.active,.nav-item.HelpButton.active a{font-size:18px}
+.nav-item a i{display:none}
 #nav-user{display:block;float:left;text-align:center;border:none}
 #nav-user.probe{font-size:1.1rem;margin-left:3px;margin-right:8px}
 #nav-tub1{position:fixed;top:56px;right:400px}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -62,17 +62,17 @@ textarea{resize:none}
 #nav-block{overflow:hidden;height:4rem;letter-spacing:1.8px}
 #nav-left{float:left}
 #nav-right{float:right}
-#nav-right #nav-item a{min-width:0}
-#nav-right #nav-item a span{display:none}
-#nav-block #nav-item,#nav-block #nav-user{float:left;display:block;text-align:center;margin:0}
-#nav-block #nav-item .system{vertical-align:middle;padding-bottom:2px;padding-right:4px}
+#nav-right .nav-item a{min-width:0}
+#nav-right .nav-item a span{display:none}
+#nav-block .nav-item,#nav-block #nav-user{float:left;display:block;text-align:center;margin:0}
+#nav-block .nav-item .system{vertical-align:middle;padding-bottom:2px;padding-right:4px}
 #nav-block #nav-user .probe{margin-left:3px;margin-right:8px}
-#nav-block #nav-item a{color:#f2f2f2;background-color:transparent;text-transform:uppercase;font-weight:bold;display:block;padding:0 10px}
-#nav-block #nav-item a{text-decoration:none;text-decoration-skip-ink:auto;-webkit-text-decoration-skip:objects;-webkit-transition:all .25s ease-out;transition:all .25s ease-out}
-#nav-block #nav-item{position:relative}
-#nav-block #nav-item:after{border-radius:4px;display:block;background-color:transparent;content:"";width:32px;height:2px;bottom:7px;position:absolute;left:50%;margin-left:-16px;-webkit-transition:all .25s ease-in-out;transition:all .25s ease-in-out;pointer-events:none}
-#nav-block #nav-item:focus:after,#nav-block #nav-item:hover:after{background-color:#f15a2c}
-#nav-block #nav-item.active:after{background-color:#f2f2f2}
+#nav-block .nav-item a{color:#f2f2f2;background-color:transparent;text-transform:uppercase;font-weight:bold;display:block;padding:0 10px}
+#nav-block .nav-item a{text-decoration:none;text-decoration-skip-ink:auto;-webkit-text-decoration-skip:objects;-webkit-transition:all .25s ease-out;transition:all .25s ease-out}
+#nav-block .nav-item{position:relative}
+#nav-block .nav-item:after{border-radius:4px;display:block;background-color:transparent;content:"";width:32px;height:2px;bottom:7px;position:absolute;left:50%;margin-left:-16px;-webkit-transition:all .25s ease-in-out;transition:all .25s ease-in-out;pointer-events:none}
+#nav-block .nav-item:focus:after,#nav-block .nav-item:hover:after{background-color:#f15a2c}
+#nav-block .nav-item.active:after{background-color:#f2f2f2}
 #txt-tub1,#txt-tub2,#txt-tub3{color:#f2f2f2}
 #clear{clear:both}
 #footer{position:fixed;bottom:0;left:0;color:#2b2a29;background-color:#d4d5d6;padding:5px 0;width:100%;height:1.6rem;line-height:1.6rem;text-align:center;z-index:10000}


### PR DESCRIPTION
Currently we use an ID for each nav item, the issue with that is IDs should be unique per page so I've moved them all to using a class instead.

Visually this doesn't change anything but there's chance this could break things with custom themes and plugins that rely on using the `#nav-item`.

PING: @limetech 