### PR TITLE
Rename docker repositories tab to template repositories

### DIFF
--- a/plugins/dynamix.docker.manager/DockerRepositories.page
+++ b/plugins/dynamix.docker.manager/DockerRepositories.page
@@ -1,11 +1,11 @@
 Menu="Docker:2"
-Title="Docker Repositories"
+Title="Template Repositories"
 Tag="clone"
 Cond="(pgrep('dockerd')!==false)"
 ---
 <?PHP
-/* Copyright 2005-2018, Lime Technology
- * Copyright 2014-2018, Guilherme Jardim, Eric Schultz, Jon Panozzo.
+/* Copyright 2005-2019, Lime Technology
+ * Copyright 2014-2019, Guilherme Jardim, Eric Schultz, Jon Panozzo.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,


### PR DESCRIPTION
We all know my preference is to completely delete this file (that was shot down a while ago), but it would solve (or at least help) with the odd user getting confused over what it actually does by naming the tab correctly