### PR TITLE
Diagnostics: Adjust for timezone from webGUI

### DIFF
--- a/plugins/dynamix/Diagnostics.page
+++ b/plugins/dynamix/Diagnostics.page
@@ -22,8 +22,9 @@ $zip = htmlspecialchars(str_replace(' ','_',strtolower($var['NAME'])));
 
 <script>
 function zipfile(){
-  var d = new Date();
-  return '<?=$zip?>-diagnostics-'+d.toISOString().substr(0,16).replace(/[-:]/g,'').replace('T','-')+'.zip';
+  var tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
+  var localISOTime = (new Date(Date.now() - tzoffset)).toISOString().slice(0, -1);
+  return '<?=$zip?>-diagnostics-'+localISOTime.substr(0,16).replace(/[-:]/g,'').replace('T','-')+'.zip';
 }
 function cleanUp(file) {
   if (document.hasFocus()) {


### PR DESCRIPTION
The filename generated by the webGUI's diagnostics wouldn't take into account the user's time zone.  (Time would always be UTC/GMT)

Set the filename according to the date / time on the browser