### PR TITLE
Add default to theme switch

### DIFF
--- a/plugins/dynamix/Syslinux.page
+++ b/plugins/dynamix/Syslinux.page
@@ -47,6 +47,7 @@ case 'white':
   echo "textarea.menu{margin-left:33.33%;width:65.5%;margin-bottom:12px;padding:4px 10px;font-family:bitstream;border:1px solid #1c1b1b;border-top:none}\n";
   break;
 case 'black':
+default:
   echo "span.array,span.system{margin-left:33.33%;width:65.5%;padding:2px 10px;font-weight:bold;border:solid 1px #f2f2f2;border-bottom:none}\n";
   echo "textarea.menu{margin-left:33.33%;width:65.5%;margin-bottom:12px;padding:4px 10px;font-family:bitstream;border:1px solid #f2f2f2;border-top:none}\n";
   break;


### PR DESCRIPTION
This was hardcoded for four specific theme filenames. This line adds a default case so custom themes are better supported.