### PR TITLE
autocapitalize="none"

### DIFF
--- a/login.php
+++ b/login.php
@@ -339,7 +339,7 @@ $theme_dark = in_array($display['theme'],['black','gray']);
 
                 <form action="/login" method="POST">
                     <p>
-                        <input name="username" type="text" placeholder="Username" required>
+                        <input name="username" type="text" placeholder="Username" autocapitalize="none" required>
                         <input name="password" type="password" placeholder="Password" required>
                     </p>
                     <? if ($error) echo '<p class="error">'.$error.'</p>'; ?>


### PR DESCRIPTION
Prevent mobile browsers from changing username "root" to "Root"