### PR TITLE
Docker: Set connection timeout on template / icon downloads to 15 sec…

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -68,9 +68,22 @@ class DockerTemplates {
 		return false;
 	}
 
-	public function download_url($url, $path='', $bg=false) {
-		exec('curl --max-time 60 --silent --insecure --location --fail '.($path ? ' -o '.escapeshellarg($path) : '').' '.escapeshellarg($url).' '.($bg ? '>/dev/null 2>&1 &' : '2>/dev/null'), $out, $exit_code);
-		return $exit_code===0 ? implode("\n", $out) : false;
+	public function download_url($url, $path='') {
+		$ch = curl_init();
+		curl_setopt($ch,CURLOPT_URL,$url);
+		curl_setopt($ch,CURLOPT_FRESH_CONNECT,true);
+		curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($ch,CURLOPT_CONNECTTIMEOUT,15);
+		curl_setopt($ch,CURLOPT_TIMEOUT,45);
+		curl_setopt($ch,CURLOPT_ENCODING,"");
+		curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		$out = curl_exec($ch);
+		curl_close($ch);
+		if ( $path )
+			file_put_contents($path,$out);
+
+		return $out ?: false;
 	}
 
 	public function listDir($root, $ext=null) {


### PR DESCRIPTION
15 sec connect and 45 sec transfer rather than the combined 60 sec

Also removed support for background transfers as nothing in dockerMan currently uses it. 