### PR TITLE
Block referrals to 3rd Party Sites

### DIFF
--- a/logging.htm
+++ b/logging.htm
@@ -3,6 +3,7 @@
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <style>
 @font-face{
 font-family:'clear-sans';font-weight:normal;font-style:normal;

--- a/login.php
+++ b/login.php
@@ -62,6 +62,7 @@ $theme_dark = in_array($display['theme'],['black','gray']);
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="robots" content="noindex, nofollow">
     <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+    <meta name="referrer" content="same-origin">
     <title><?=$var['NAME']?>/Login</title>
     <style>
     /************************

--- a/plugins/dynamix.docker.manager/include/ContainerSize.php
+++ b/plugins/dynamix.docker.manager/include/ContainerSize.php
@@ -22,6 +22,7 @@ require_once "$docroot/webGui/include/Helpers.php";
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/font-awesome.css")?>">

--- a/plugins/dynamix.docker.manager/log.htm
+++ b/plugins/dynamix.docker.manager/log.htm
@@ -3,6 +3,7 @@
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <style>
 @font-face{
 font-family:'clear-sans';font-weight:normal;font-style:normal;

--- a/plugins/dynamix.plugin.manager/include/ShowChanges.php
+++ b/plugins/dynamix.plugin.manager/include/ShowChanges.php
@@ -20,6 +20,7 @@ require_once "$docroot/webGui/include/Helpers.php";
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 </head>

--- a/plugins/dynamix/include/Boot.php
+++ b/plugins/dynamix/include/Boot.php
@@ -22,6 +22,7 @@ $var = parse_ini_file("/var/local/emhttp/var.ini");
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
 <link type="text/css" rel="stylesheet" href="<?autov('/webGui/styles/default-fonts.css')?>">
+<meta name="referrer" content="same-origin">
 <style>
 html{font-family:clear-sans;font-size:62.5%;height:100%}
 body{font-size:1.3rem;color:#1c1c1c;background:#f2f2f2;padding:0;margin:0;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}

--- a/plugins/dynamix/include/CryptoBenchmark.php
+++ b/plugins/dynamix/include/CryptoBenchmark.php
@@ -27,6 +27,7 @@ $hash = trim(explode(':',$hash)[1]);
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/font-awesome.css")?>">

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -28,6 +28,7 @@ $themes2 = in_array($theme,['gray','azure']);
 <meta name="viewport" content="width=1440">
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="image/png" rel="shortcut icon" href="/webGui/images/<?=$var['mdColor']?>.png">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-cases.css")?>">

--- a/plugins/dynamix/include/Feedback.php
+++ b/plugins/dynamix/include/Feedback.php
@@ -31,6 +31,7 @@ if (array_key_exists('getdiagnostics', $_GET)) {
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <style>

--- a/plugins/dynamix/include/ParityHistory.php
+++ b/plugins/dynamix/include/ParityHistory.php
@@ -34,6 +34,7 @@ function his_duration($time) {
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 </head>

--- a/plugins/dynamix/include/ReplaceKey.php
+++ b/plugins/dynamix/include/ReplaceKey.php
@@ -21,6 +21,7 @@ $keyfile = base64_encode(file_get_contents($var['regFILE']));
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <script src="<?autov('/webGui/javascript/dynamix.js')?>"></script>

--- a/plugins/dynamix/include/SelectCase.php
+++ b/plugins/dynamix/include/SelectCase.php
@@ -47,6 +47,7 @@ $casemodel = $exist ? file_get_contents("$boot/$file") : '';
 <meta name="viewport" content="width=1440">
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-cases.css")?>">

--- a/plugins/dynamix/include/SystemInformation.php
+++ b/plugins/dynamix/include/SystemInformation.php
@@ -36,6 +36,7 @@ function dmidecode($key,$n,$all=true) {
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <style>

--- a/plugins/dynamix/include/TrialRequest.php
+++ b/plugins/dynamix/include/TrialRequest.php
@@ -25,6 +25,7 @@ if (!empty($_POST['trial'])) {
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-fonts.css")?>">
 <link type="text/css" rel="stylesheet" href="<?autov("/webGui/styles/default-popup.css")?>">
 <script src="<?autov('/webGui/javascript/dynamix.js')?>"></script>

--- a/update.htm
+++ b/update.htm
@@ -3,6 +3,7 @@
 <head>
 <meta name="robots" content="noindex, nofollow">
 <meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<meta name="referrer" content="same-origin">
 <style>
 @font-face{
 font-family:'clear-sans';font-weight:normal;font-style:normal;


### PR DESCRIPTION
This adds `<meta name="referrer" content="same-origin">` to all pages, which will prevent browsers from sending referrer information when linking offsite.  See:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy