### PR TITLE
Notifications: Add switch to not send a browser notification

### DIFF
--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -1,7 +1,7 @@
 #!/usr/bin/php -q
 <?PHP
-/* Copyright 2005-2019, Lime Technology
- * Copyright 2012-2019, Bergware International.
+/* Copyright 2005-2020, Lime Technology
+ * Copyright 2012-2020, Bergware International.
  * Copyright 2012, Andrew Hamer-Adams, http://www.pixeleyes.co.nz.
  *
  * This program is free software; you can redistribute it and/or
@@ -19,7 +19,7 @@ require_once "$docroot/webGui/include/Encryption.php";
 
 function usage() {
   echo <<<EOT
-notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"] [-m "message"] [-x] [-t] [add]
+notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"] [-m "message"] [-x] [-t] [-b] [add]
   create a notification
   use -e to specify the event
   use -s to specify a subject
@@ -29,6 +29,7 @@ notify [-e "event"] [-s "subject"] [-d "description"] [-i "normal|warning|alert"
   use -x to create a single notification ticket
   use -r to specify recipients and not use default
   use -t to force send email only (for testing)
+  use -b to NOT send a browser notification
   all options are optional
 
 notify init
@@ -164,7 +165,7 @@ case 'add':
   $mailtest = false;
   $overrule = false;
 
-  $options = getopt("e:s:d:i:m:r:xt");
+  $options = getopt("e:s:d:i:m:r:xtb");
   foreach ($options as $option => $value) {
     switch ($option) {
      case 'e':
@@ -192,14 +193,18 @@ case 'add':
      case 't':
       $mailtest = true;
       break;
+     case 'b':
+      $noBrowser = true;
+      break;
     }
   }
+	
   $unread = "{$unread}/".safe_filename("{$event}-{$ticket}.notify");
   $archive = "{$archive}/".safe_filename("{$event}-{$ticket}.notify");
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   if (!$mailtest) file_put_contents($archive,"timestamp=$timestamp\nevent=$event\nsubject=$subject\ndescription=$description\nimportance=$importance\n".($message ? "message=".str_replace('\n','<br>',$message)."\n" : ""));
-  if (($entity & 1)==1 && !$mailtest) file_put_contents($unread,"timestamp=$timestamp\nevent=$event\nsubject=$subject\ndescription=$description\nimportance=$importance\n");
+  if (($entity & 1)==1 && !$mailtest && !$noBrowser) file_put_contents($unread,"timestamp=$timestamp\nevent=$event\nsubject=$subject\ndescription=$description\nimportance=$importance\n");
   if (($entity & 2)==2 || $mailtest)  if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message, $recipients)) exit(1);
   if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg($subject)." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." bash ".$agent);};}};
   break;


### PR DESCRIPTION
Will be utilized by CA to send a notification, but not have the notification appear on the browser but rather as a banner warning