### PR TITLE
Dashboard: Fix Update not showing for docker apps

### DIFF
--- a/plugins/dynamix/include/DashboardApps.php
+++ b/plugins/dynamix/include/DashboardApps.php
@@ -49,7 +49,7 @@ if ($_POST['docker'] && ($display=='icons' || $display=='docker')) {
     $shape = $running ? ($paused ? 'pause' : 'play') : 'square';
     $status = $running ? ($paused ? 'paused' : 'started') : 'stopped';
     $color = $status=='started' ? 'green-text' : ($status=='paused' ? 'orange-text' : 'red-text');
-    $update = $updateStatus=='false' ? 'blue-text' : '';
+    $update = $updateStatus==1 ? 'blue-text' : '';
     $icon = $info['icon'] ?: '/plugins/dynamix.docker.manager/images/question.png';
     $image = substr($icon,-4)=='.png' ? "<img src='$icon?".filemtime("$docroot{$info['icon']}")."' class='img'>" : (substr($icon,0,5)=='icon-' ? "<i class='$icon img'></i>" : "<i class='fa fa-$icon img'></i>");
     echo "<span class='outer solid apps $status'><span id='$id' class='hand'>$image</span><span class='inner'><span class='$update'>$name</span><br><i class='fa fa-$shape $status $color'></i><span class='state'>$status</span></span></span>";

--- a/plugins/dynamix/include/DashboardApps.php
+++ b/plugins/dynamix/include/DashboardApps.php
@@ -38,7 +38,7 @@ if ($_POST['docker'] && ($display=='icons' || $display=='docker')) {
     $running = $info['running'] ? 1:0;
     $paused = $info['paused'] ? 1:0;
     $is_autostart = $info['autostart'] ? 'true':'false';
-    $updateStatus = $info['updated']=='true'||$info['updated']=='undef' ? 'true':'false';
+    $updateStatus = substr($ct['NetworkMode'],-4)==':???' ? 2 : ($info['updated']=='true' ? 0 : ($info['updated']=='false' ? 1 : 3));
     $template = $info['template'];
     $shell = $info['shell'];
     $webGui = html_entity_decode($info['url']);


### PR DESCRIPTION
Match the same logic used on the docker page (dashboard context menu wasn't offering update on a container) (and the coloring of the text was off when using a private docker repository)

Fixes https://forums.unraid.net/topic/89462-unraid-os-version-683-available/?tab=comments#comment-830202
