### PR TITLE
Cache plugin .cfg reads from flash drive

### DIFF
--- a/plugins/dynamix/include/Wrappers.php
+++ b/plugins/dynamix/include/Wrappers.php
@@ -23,7 +23,7 @@ function parse_plugin_cfg($plugin, $sections=false, $scanner=INI_SCANNER_NORMAL)
     @mkdir(dirname($cache),0777,true);
     @copy($rom,$cache);
   }
-  $cfg = file_exists($cache) ? parse_ini_file($ram, $sections, $scanner) : [];
+  $cfg = file_exists($ram) ? parse_ini_file($ram, $sections, $scanner) : [];
   return file_exists($cache) ? array_replace_recursive($cfg, parse_ini_file($cache, $sections, $scanner)) : $cfg;
 }
 function parse_cron_cfg($plugin, $job, $text = "") {

--- a/plugins/dynamix/include/Wrappers.php
+++ b/plugins/dynamix/include/Wrappers.php
@@ -19,7 +19,7 @@ function parse_plugin_cfg($plugin, $sections=false, $scanner=INI_SCANNER_NORMAL)
   $ram   = "$docroot/plugins/$plugin/default.cfg";
   $cache = "$docroot/state/cfg/$plugin.cfg";
   $rom   = "/boot/config/plugins/$plugin/$plugin.cfg";
-  if ( ! is_file($cache) ) {
+  if ( ! is_file($cache) && file_exists($rom) ) {
     @mkdir(dirname($cache),0777,true);
     @copy($rom,$cache);
   }

--- a/plugins/dynamix/include/Wrappers.php
+++ b/plugins/dynamix/include/Wrappers.php
@@ -16,10 +16,15 @@ $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
 // Wrapper functions
 function parse_plugin_cfg($plugin, $sections=false, $scanner=INI_SCANNER_NORMAL) {
   global $docroot;
-  $ram = "$docroot/plugins/$plugin/default.cfg";
-  $rom = "/boot/config/plugins/$plugin/$plugin.cfg";
-  $cfg = file_exists($ram) ? parse_ini_file($ram, $sections, $scanner) : [];
-  return file_exists($rom) ? array_replace_recursive($cfg, parse_ini_file($rom, $sections, $scanner)) : $cfg;
+  $ram   = "$docroot/plugins/$plugin/default.cfg";
+  $cache = "$docroot/state/cfg/$plugin.cfg";
+  $rom   = "/boot/config/plugins/$plugin/$plugin.cfg";
+  if ( ! is_file($cache) ) {
+    @mkdir(dirname($cache),0777,true);
+    @copy($rom,$cache);
+  }
+  $cfg = file_exists($cache) ? parse_ini_file($ram, $sections, $scanner) : [];
+  return file_exists($cache) ? array_replace_recursive($cfg, parse_ini_file($cache, $sections, $scanner)) : $cfg;
 }
 function parse_cron_cfg($plugin, $job, $text = "") {
   $cron = "/boot/config/plugins/$plugin/$job.cron";

--- a/update.php
+++ b/update.php
@@ -72,7 +72,7 @@ if (isset($_POST['#file'])) {
       foreach ($keys as $key => $value) if (strlen($value) || !$cleanup) $text .= "$key=\"$value\"\n";
     }
     @mkdir(dirname($file));
-    $ramfile = "/usr/local/emhttp/state/cfg/".basename($file);
+    $ramfile = "$docroot/state/cfg/".basename($file);
 
     mkdir(dirname($ramfile),0777,true);
     file_put_contents($ramfile,$text);

--- a/update.php
+++ b/update.php
@@ -72,6 +72,10 @@ if (isset($_POST['#file'])) {
       foreach ($keys as $key => $value) if (strlen($value) || !$cleanup) $text .= "$key=\"$value\"\n";
     }
     @mkdir(dirname($file));
+    $ramfile = "/usr/local/emhttp/state/cfg/".basename($file);
+
+    mkdir(dirname($ramfile),0777,true);
+    file_put_contents($ramfile,$text);
     file_put_contents($file, $text);
   }
 }


### PR DESCRIPTION
Not really sure if this is an actual thing or not https://en.wikipedia.org/wiki/Flash_memory#Read_disturb , but it is rather disturbing the amount of flash drive corruption that happens, seemingly out of no where.  (And I personally wouldn't ever count on a flash drive's controller being halfway decent and detecting this) (Dynamix' monitor reads the same file every minute on the minute).  If nothing else, it will give a speed bump
