### PR TITLE
Multi-language support

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -165,6 +165,7 @@ function settab(tab) {
 }
 function done(key) {
   var url = location.pathname.split('/');
+  // Ensure Done() goes back to CA if referrer is CA
   if (location.pathname.indexOf("/Apps/") != -1 ) 
     var path = "/Apps";
   else 

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -165,7 +165,7 @@ function settab(tab) {
 }
 function done(key) {
   var url = location.pathname.split('/');
-  if (url.indexOf("/Apps/")) 
+  if (location.pathname.indexOf("/Apps/") != -1 ) 
     var path = "/Apps";
   else 
     var path = '/'+url[1];

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -165,7 +165,7 @@ function settab(tab) {
 }
 function done(key) {
   var url = location.pathname.split('/');
-  var path = '/'+url[1];
+  var path = '/'+url[url.length - 2];
   if (key) for (var i=2; i<url.length; i++) if (url[i]==key) break; else path += '/'+url[i];
   $.removeCookie('one',{path:'/'});
   location.replace(path);

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -165,7 +165,10 @@ function settab(tab) {
 }
 function done(key) {
   var url = location.pathname.split('/');
-  var path = '/'+url[url.length - 2];
+  if (url.indexOf("/Apps/")) 
+    var path = "/Apps";
+  else 
+    var path = '/'+url[1];
   if (key) for (var i=2; i<url.length; i++) if (url[i]==key) break; else path += '/'+url[i];
   $.removeCookie('one',{path:'/'});
   location.replace(path);


### PR DESCRIPTION
Required for CA to support multi-language.

Here's the story

When on multi-language, if the user selects "Dutch", then CA operates in Dutch.  However when installing a container from CA, the language on the Add Container screen will revert to English.

The workaround for that is for CA to specify the install URL as /Docker/Apps/AddContainer... instead of the current /Apps/AddContainer.

But, that change breaks the "Done" Button in returning to CA.  This change fixes that.  Doesn't appear to affect anywhere else in the UI where the Done button is also present, but @bergware might want to double check that