### PR TITLE
Allow duplicate containers different icons

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -85,7 +85,7 @@ if (isset($_POST['contName'])) {
       $oldXML = simplexml_load_file($filename);
       if ($oldXML->Icon != $_POST['contIcon']) {
         if (!strpos($Repository,":")) $Repository .= ":latest";
-        $iconPath = $DockerTemplates->getIcon($Repository);
+        $iconPath = $DockerTemplates->getIcon($Repository,$Name);
         @unlink("$docroot/$iconPath");
         @unlink("{$dockerManPaths['images']}/".basename($iconPath));
       }

--- a/plugins/dynamix/ArrayOperation.page
+++ b/plugins/dynamix/ArrayOperation.page
@@ -306,7 +306,7 @@ function formatWarning(val) {
         <tr><td></td><td><input type="submit" name="cmdCheck" value="_(Clear)_"></td><td>**_(Clear)_** _(will start **Clearing** new data disk(s))_.</td></tr>
 <?    else:
         if ($var['mdResyncAction']=="check"):?>
-          <tr><td></td><td><input type="submit" name="cmdCheck" value="_(Check)_"></td><td>**_(Check)_** _ (will start **Read-Check** of all array disks)_.</td></tr>
+          <tr><td></td><td><input type="submit" name="cmdCheck" value="_(Check)_"></td><td>**_(Check)_** _(will start **Read-Check** of all array disks)_.</td></tr>
 <?      elseif (strstr($var['mdResyncAction'],"check")):?>
           <tr><td>_(Parity is valid)_.</td><td><input type="submit" name="cmdCheck" value="_(Check)_"></td><td>**_(Check)_** _(will start **Parity-Check**)_.&nbsp;&nbsp;<a href="/Main/Scheduler"<?if ($tabbed):?> onclick="$.cookie('one','tab1',{path:'/'})"<?endif;?>>(_(Schedule)_)</a>
           <br><input type="checkbox" name="optionCorrect" value="correct" checked><small>_(Write corrections to parity)_</small></td></tr>
@@ -488,7 +488,7 @@ function formatWarning(val) {
         <td>_(Too many wrong and/or missing disks)_!</td></tr>
 <?      break;
       case "ERROR:NO_DATA_DISKS":?>
-        <tr><td><?status_indicator()?>**_(Stopped)_**. _ (No data disks)_.</td><td><input type="submit" name="cmdStart" value="_(Start)_" disabled></td>
+        <tr><td><?status_indicator()?>**_(Stopped)_**. _(No data disks)_.</td><td><input type="submit" name="cmdStart" value="_(Start)_" disabled></td>
         <td>_(No array data disks have been assigned)_!</td></tr>
 <?      break;
       endswitch;
@@ -545,7 +545,7 @@ function formatWarning(val) {
  <tr><td></td><td class="line" colspan="2"></td></tr>
 </table>
 </form>
-<!-- markdown fix --></p><?if (isset($display['sleep'])) @include $display['sleep'];?>
+<!-- markdown fix --></p><?if (isset($display['sleep'])) eval('?>'.parse_file($display['sleep']))?>
 <?if ($btrfs):?>
 <script>
 function enable_stop() {


### PR DESCRIPTION
It's the one place in the docker UI where changing an element on one of the duplicated containers will not take effect or affects both of them -> depending upon the alphabetical order of the containers.

Multiple instances of containers are far more prevalent now than when dockerMan was first introduced, and the original method of tagging to reflect different apps installed is no longer sufficient.

Minor downside is that a re-download of all the icons will happen when _first_ hitting either dashboard or docker pages to reflect the new naming scheme.