### PR TITLE
Added support for private docker registries with basic auth or no auth, and improvements for token based authentication

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -851,7 +851,7 @@ class DockerClient {
 		foreach ($this->getDockerJSON("/containers/json?all=1") as $ct) {
 			$info = $this->getContainerDetails($ct['Id']);
 			$c = [];
-			$c['Image']       = DockerUtil::ensureImageTag($ct['Image']);
+			$c['Image']       = DockerUtil::ensureImageTag($info['Config']['Image']);
 			$c['ImageId']     = $this->extractID($ct['ImageID']);
 			$c['Name']        = substr($info['Name'], 1);
 			$c['Status']      = $ct['Status'] ?: 'None';


### PR DESCRIPTION
This fixes the "Check for updates" button not working for images from private docker registries that don't use Bearer tokens for authentication. I tested this using the DockerRegistry container from Community Applications and Traefik providing the basic auth.