### PR TITLE
Task Plugins: Providing Ability to define Display_Name

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -433,9 +433,9 @@ foreach ($tasks as $button) {
   echo "<div id='nav-item'";
   echo $task==$page ? " class='active'>" : ">";
   if (!isset($display_name)) {
-    echo "<a href='/$page' onclick='initab()'>$page</a></div>";
+    echo "<a href='/$page' onclick='initab()'>". _($page) ."</a></div>";
   } else {
-    echo "<a href='/$page' onclick='initab()'>$display_name</a></div>";
+    echo "<a href='/$page' onclick='initab()'>". _($display_name) ."</a></div>";
   }
 }
 unset($tasks);

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -426,9 +426,17 @@ $(function() {
 echo "<div id='menu'><div id='nav-block'><div id='nav-left'>";
 foreach ($tasks as $button) {
   $page = $button['name'];
+  $display_name = null;
+  if (isset($button['Display_Name'])) {
+    $display_name = $button['Display_Name'];
+  }
   echo "<div id='nav-item'";
   echo $task==$page ? " class='active'>" : ">";
-  echo "<a href='/$page' onclick='initab()'>"._($page)."</a></div>";
+  if (!isset($display_name)) {
+    echo "<a href='/$page' onclick='initab()'>$page</a></div>";
+  } else {
+    echo "<a href='/$page' onclick='initab()'>$display_name</a></div>";
+  }
 }
 unset($tasks);
 if ($display['usage']) my_usage();

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -426,17 +426,9 @@ $(function() {
 echo "<div id='menu'><div id='nav-block'><div id='nav-left'>";
 foreach ($tasks as $button) {
   $page = $button['name'];
-  $display_name = null;
-  if (isset($button['Display_Name'])) {
-    $display_name = $button['Display_Name'];
-  }
   echo "<div id='nav-item'";
   echo $task==$page ? " class='active'>" : ">";
-  if (is_null($display_name)) {
-    echo "<a href='/$page' onclick='initab()'>". _($page) ."</a></div>";
-  } else {
-    echo "<a href='/$page' onclick='initab()'>". _($display_name) ."</a></div>";
-  }
+  echo "<a href='/$page' onclick='initab()'>"._($button['Name'] ?? $page)."</a></div>";
 }
 unset($tasks);
 if ($display['usage']) my_usage();

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -432,7 +432,7 @@ foreach ($tasks as $button) {
   }
   echo "<div id='nav-item'";
   echo $task==$page ? " class='active'>" : ">";
-  if (!isset($display_name)) {
+  if (is_null($display_name)) {
     echo "<a href='/$page' onclick='initab()'>". _($page) ."</a></div>";
   } else {
     echo "<a href='/$page' onclick='initab()'>". _($display_name) ."</a></div>";


### PR DESCRIPTION
Gives the ability to provide a Display_Name for when displaying task menu bar as having spaces in the file name seems to mess things up further.
<img width="328" alt="Screen Shot 2020-05-02 at 9 17 59 AM" src="https://user-images.githubusercontent.com/464851/80865234-fc3a2800-8c55-11ea-937b-78494ce242eb.png">
<img width="243" alt="Screen Shot 2020-05-02 at 9 17 48 AM" src="https://user-images.githubusercontent.com/464851/80865235-fd6b5500-8c55-11ea-90f8-06e599aba258.png">

