### PR TITLE
Use update image dialog for update entry in docker context menu

### DIFF
--- a/plugins/dynamix.docker.manager/javascript/docker.js
+++ b/plugins/dynamix.docker.manager/javascript/docker.js
@@ -8,7 +8,7 @@ function addDockerContainerContext(container, image, template, started, paused, 
     opts.push({divider:true});
   }
   if (update==1) {
-    opts.push({text:_('Update'), icon:'fa-cloud-download', action:function(e){e.preventDefault(); execUpContainer(container);}});
+    opts.push({text:_('Update'), icon:'fa-cloud-download', action:function(e){e.preventDefault(); updateContainer(container);}});
     opts.push({divider:true});
   }
   if (started) {


### PR DESCRIPTION
This pull request uses the docker update dialog also for the update entry in the context menu. This makes sure that users do not accidentally update their containers.

Reference: https://forums.unraid.net/bug-reports/stable-releases/docker-image-update-dialog-missing-cosmetic-issue-r941/