### PR TITLE
Fix &apos; appearing when provisioning

### DIFF
--- a/plugins/dynamix/ManagementAccess.page
+++ b/plugins/dynamix/ManagementAccess.page
@@ -78,7 +78,7 @@ function provisionSSL(button) {
   };
   var success_rebind_check = function(data) {
     $.post("/webGui/include/CertUpload.php",{text:data.bundle,csrf_token:"<?=$var['csrf_token']?>"},function(data2) {
-      swal({title:"",text:msg,type:"success",allowEscapeKey:false,confirmButtonText:"_(Ok)_"},function(){button.form.submit();});
+      swal({title:"",text:msg,type:"success",allowEscapeKey:false,confirmButtonText:"_(Ok)_",html:true},function(){button.form.submit();});
     }).fail(failure);
   };
   $.post("/webGui/include/ProvisionCert.php",success_provision).fail(failure);


### PR DESCRIPTION
@bergware You might want to do a search on every swal call.  With multi-language, any time & apos ; shows up in a swal dialog it shows up literally without html:true being set.  This instance was obvious, since it appeared in English.