### PR TITLE
Fix/j growl notification styles

### DIFF
--- a/plugins/dynamix/styles/default-black.css
+++ b/plugins/dynamix/styles/default-black.css
@@ -60,7 +60,7 @@ textarea{resize:none}
 #title span.right{font-size:1.4rem;padding-top:2px;padding-right:10px;float:right}
 #title span img{padding-right:4px}
 #title.shift{margin-top:-30px}
-#menu{position:absolute;top:90px;left:0;width:100%;min-width:1260px;height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;background-color:#f2f2f2;z-index:99999;}
+#menu{position:absolute;top:90px;left:0;width:100%;min-width:1260px;height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;background-color:#f2f2f2;z-index:101;}
 #nav-block{overflow:hidden;height:4rem;letter-spacing:1.8px}
 #nav-left{float:left}
 #nav-right{float:right}

--- a/plugins/dynamix/styles/default-white.css
+++ b/plugins/dynamix/styles/default-white.css
@@ -60,7 +60,7 @@ textarea{resize:none}
 #title span.right{font-size:1.4rem;padding-top:2px;padding-right:10px;float:right}
 #title span img{padding-right:4px}
 #title.shift{margin-top:-30px}
-#menu{position:absolute;top:90px;left:0;width:100%;min-width:1260px;height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;background-color:#1c1b1b;z-index:99999;}
+#menu{position:absolute;top:90px;left:0;width:100%;min-width:1260px;height:4rem;line-height:4rem;padding:0;margin:0;font-size:1.2rem;background-color:#1c1b1b;z-index:101;}
 #nav-block{overflow:hidden;height:4rem;letter-spacing:1.8px}
 #nav-left{float:left}
 #nav-right{float:right}

--- a/plugins/dynamix/styles/dynamix-azure.css
+++ b/plugins/dynamix/styles/dynamix-azure.css
@@ -1,9 +1,9 @@
 .jGrowl{position:fixed;z-index:9999;font-size:1.3rem}
-.jGrowl.top-left{left:10px;top:100px}
-.jGrowl.top-right{right:10px;top:100px}
+.jGrowl.top-left{left:10px;top:90px}
+.jGrowl.top-right{right:10px;top:90px}
 .jGrowl.bottom-left{left:10px;bottom:24px}
 .jGrowl.bottom-right{right:10px;bottom:24px}
-.jGrowl.center{top:100px;left:40%}
+.jGrowl.center{top:90px;left:40%}
 .jGrowl.center .jGrowl-closer,.jGrowl.center .jGrowl-notification{margin-left:auto;margin-right:auto}
 .jGrowl-notification.alert{color:#f0000c;background-color:#ff9e9e;opacity:0.96;border:1px solid #f0000c;box-shadow:2px 2px 1px #888888}
 .jGrowl-notification.warning{color:#e68a00;background-color:#feefb3;opacity:0.96;border:1px solid #e68a00;box-shadow:2px 2px 1px #888888}

--- a/plugins/dynamix/styles/dynamix-black.css
+++ b/plugins/dynamix/styles/dynamix-black.css
@@ -1,9 +1,9 @@
 .jGrowl{position:fixed;z-index:9999;font-size:1.3rem}
-.jGrowl.top-left{left:10px;top:100px}
-.jGrowl.top-right{right:10px;top:100px}
+.jGrowl.top-left{left:10px;top:130px}
+.jGrowl.top-right{right:10px;top:130px}
 .jGrowl.bottom-left{left:10px;bottom:24px}
 .jGrowl.bottom-right{right:10px;bottom:24px}
-.jGrowl.center{top:100px;left:40%}
+.jGrowl.center{top:130px;left:40%}
 .jGrowl.center .jGrowl-closer,.jGrowl.center .jGrowl-notification{margin-left:auto;margin-right:auto}
 .jGrowl-notification.alert{color:#f0000c;background-color:#ff9e9e;opacity:0.96;border:1px solid #f0000c;box-shadow:2px 2px 1px #888888}
 .jGrowl-notification.warning{color:#e68a00;background-color:#feefb3;opacity:0.96;border:1px solid #e68a00;box-shadow:2px 2px 1px #888888}

--- a/plugins/dynamix/styles/dynamix-gray.css
+++ b/plugins/dynamix/styles/dynamix-gray.css
@@ -1,9 +1,9 @@
 .jGrowl{position:fixed;z-index:9999;font-size:1.3rem}
-.jGrowl.top-left{left:10px;top:100px}
-.jGrowl.top-right{right:10px;top:100px}
+.jGrowl.top-left{left:10px;top:90px}
+.jGrowl.top-right{right:10px;top:90px}
 .jGrowl.bottom-left{left:10px;bottom:24px}
 .jGrowl.bottom-right{right:10px;bottom:24px}
-.jGrowl.center{top:100px;left:40%}
+.jGrowl.center{top:90px;left:40%}
 .jGrowl.center .jGrowl-closer,.jGrowl.center .jGrowl-notification{margin-left:auto;margin-right:auto}
 .jGrowl-notification.alert{color:#f0000c;background-color:#ff9e9e;opacity:0.96;border:1px solid #f0000c;box-shadow:2px 2px 1px #888888}
 .jGrowl-notification.warning{color:#e68a00;background-color:#feefb3;opacity:0.96;border:1px solid #e68a00;box-shadow:2px 2px 1px #888888}

--- a/plugins/dynamix/styles/dynamix-white.css
+++ b/plugins/dynamix/styles/dynamix-white.css
@@ -1,9 +1,9 @@
 .jGrowl{position:fixed;z-index:9999;font-size:1.3rem}
-.jGrowl.top-left{left:10px;top:100px}
-.jGrowl.top-right{right:10px;top:100px}
+.jGrowl.top-left{left:10px;top:130px}
+.jGrowl.top-right{right:10px;top:130px}
 .jGrowl.bottom-left{left:10px;bottom:24px}
 .jGrowl.bottom-right{right:10px;bottom:24px}
-.jGrowl.center{top:100px;left:40%}
+.jGrowl.center{top:130px;left:40%}
 .jGrowl.center .jGrowl-closer,.jGrowl.center .jGrowl-notification{margin-left:auto;margin-right:auto}
 .jGrowl-notification.alert{color:#f0000c;background-color:#ff9e9e;opacity:0.96;border:1px solid #f0000c;box-shadow:2px 2px 1px #888888}
 .jGrowl-notification.warning{color:#e68a00;background-color:#feefb3;opacity:0.96;border:1px solid #e68a00;box-shadow:2px 2px 1px #888888}


### PR DESCRIPTION
Unfortunately the introduction of `#menu {…z-index:99999;}` introduced a few bugs – like with the Shadowboxes and other various elements that should have z-index priority. 

These suggested top value changes prevent `jGrowl` from overlapping the #menu DOM element.

There's another bug here with `jGrowl` creating an empty `<div class="jGrowl-notification"></div>`. Regardless these changes are still needed.