### PR TITLE
New Perms Support Cache Pools

### DIFF
--- a/plugins/dynamix/NewPerms.page
+++ b/plugins/dynamix/NewPerms.page
@@ -17,9 +17,8 @@ Tag="folder-o"
 ?>
 <?
 $width = [166,300];
-
 function data_disks($disk) {
-  return ($disk['type']=='Data' && $disk['status']=='DISK_OK');
+  return ( ($disk['type']=='Data' || $disk['type'] == "Cache") && $disk['status']=='DISK_OK');
 }
 ?>
 <style>
@@ -93,9 +92,6 @@ Note that this tool may negatively affect any docker containers if you allow you
 <span class="block"><div class="div">_(Disks)_</div>
 <select id="s1" name="includeDisk" size="1" multiple="multiple" style="display:none">
 <option value=''>_(All)_</option>
-<?if (isset($disks['cache'])):?>
-<option value='/mnt/cache'>_(Cache)_</option>
-<?endif;?>
 <?foreach (array_filter($disks,'data_disks') as $disk):?>
 <?=mk_option(1,"/mnt/{$disk['name']}",_(my_disk($disk['name'])),3)?>
 <?endforeach;?>

--- a/plugins/dynamix/scripts/newperms
+++ b/plugins/dynamix/scripts/newperms
@@ -39,12 +39,11 @@ function process {
 if [[ -n $1 ]]; then
   process "$@"
 else
-  process /mnt/cache
-  for disk in /mnt/disk[0-9]*; do
-    process $disk
-  done
+  /usr/local/emhttp/plugins/dynamix/scripts/newperms.php
 fi
 
 echo
 secs=$SECONDS
-printf "completed, elapsed time: %.2d:%.2d:%.2d\n" $(($secs/3600)) $(($secs%3600/60)) $(($secs%60))
+if [[ ! -n $1 ]]; then 
+  printf "completed, elapsed time: %.2d:%.2d:%.2d\n" $(($secs/3600)) $(($secs%3600/60)) $(($secs%60))
+fi

--- a/plugins/dynamix/scripts/newperms.php
+++ b/plugins/dynamix/scripts/newperms.php
@@ -1,0 +1,9 @@
+#!/usr/bin/php
+<?
+$disks = parse_ini_file("/var/local/emhttp/disks.ini",true);
+foreach ($disks as $disk => $prop) {
+	if ( is_dir("/mnt/$disk") && $prop['status'] !== "DISK_NP_DSBL" && $prop['status'] !== "DISK_NP") {
+		passthru("/usr/local/emhttp/plugins/dynamix/scripts/newperms ".escapeshellarg("/mnt/$disk"));
+	}
+}
+?>


### PR DESCRIPTION
Use PHP to determine the cache pools from disks.ini  Should be future safe and will ignore anything a user happens to drop into /mnt

Honestly didn't want to invest the time to unify this script into a single language as it really should never be used in the first place, hence the wrapper call.