### PR TITLE
dockerMan: Only allow name compatible with docker

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -716,7 +716,7 @@ _(Template)_:
 
 <div markdown="1" class="<?=$showAdditionalInfo?>">
 _(Name)_:
-: <input type="text" name="contName" required>
+: <input type="text" name="contName" pattern="[a-zA-Z0-9][a-zA-Z0-9_.-]+" required>
 
 :docker_client_name_help:
 


### PR DESCRIPTION
2 characters minimum, must start with a-zA-Z0-9 2nd+ characters a-zA-z0-0.-_