### PR TITLE
improve: helper autov(), fail syntax error prevent

### DIFF
--- a/plugins/dynamix/include/Helpers.php
+++ b/plugins/dynamix/include/Helpers.php
@@ -231,7 +231,8 @@ function autov($file,$ret=false) {
   global $docroot;
   $path = $docroot.$file;
   clearstatcache(true, $path);
-  $newFile = "$file?v=".filemtime($path);
+  $time = strlen(@filemtime($path)) ? @filemtime($path) : 'autov_fileDoesntExist';
+  $newFile = "$file?v=".$time;
   if ($ret)
     return $newFile;
   else


### PR DESCRIPTION
Slightly tweaks the `autov()` helper function to prevent the failing with a syntax error when the file doesn't exist. When the function fails it will now append a fallback of `autov_fileDoesntExist` as the query string to signify `autov()` failure.

This should help with certain troubleshooting situations.