### PR TITLE
Fix: Dashboard / Docker scrolling on iPad devices

### DIFF
--- a/plugins/dynamix.docker.manager/DockerContainers.page
+++ b/plugins/dynamix.docker.manager/DockerContainers.page
@@ -28,6 +28,7 @@ $cpus = cpu_list();
 <style>
 .basic{display:block}
 .advanced{display:none;white-space:nowrap}
+.dockerhandle{cursor:grab;}
 .log{cursor:zoom-in}
 .exec{cursor:pointer}
 table#docker_containers{text-align:left}
@@ -40,7 +41,7 @@ table tbody td{line-height:normal}
 <div id="iframe-popup" style="display:none;-webkit-overflow-scrolling:touch;"></div>
 <span class="status" style="margin-top:<?=$width?>px"><span><input type="checkbox" class="advancedview"></span></span>
 <table id="docker_containers" class="tablesorter shift">
-<thead><tr><th><a href="#" style="cursor:hand;margin-left:12px;display:inline-block;width:32px" onclick="resetSorting()" title="_(Reset sorting)_"><i class="fa fa-th-list"></i></a>_(Application)_</th><th>_(Version)_</th><th>_(Network)_</th><th>_(Port Mappings)_ <small>(_(App to Host)_)</small></th><th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th><th class="load advanced">_(CPU & Memory load)_</th><th class="nine">_(Autostart)_</th><th class="five">_(Uptime)_</th></tr></thead>
+<thead><tr><th><a href="#" style="cursor:hand;margin-left:12px;display:inline-block;width:32px" onclick="resetSorting()" title="_(Reset sorting)_"><i class="fa fa-th-list"></i></a>_(Application)_</th><th>_(Version)_</th><th>_(Network)_</th><th>_(Port Mappings)_ <small>(_(App to Host)_)</small></th><th>_(Volume Mappings)_ <small>(_(App to Host)_)</small></th><th class="load advanced">_(CPU & Memory load)_</th><th class="nine">_(Autostart)_</th><th class="five">_(Uptime)_</th><th></th></tr></thead>
 <tbody id="docker_list"><tr><td colspan='9'></td></tr></tbody>
 </table>
 <input type="button" onclick="addContainer()" value="_(Add Container)_" style="display:none">
@@ -102,7 +103,7 @@ function loadlist() {
   $.get('/plugins/dynamix.docker.manager/include/DockerContainers.php',function(d) {
     clearTimeout(timers.docker);
     var data = d.split(/\0/);
-    $('#docker_list').html(data[0]).sortable({helper:sortableHelper,items:'tr.sortable',cursor:'move',axis:'y',containment:'parent',cancel:'span.docker_readmore,input',delay:100,opacity:0.5,zIndex:9999,
+    $('#docker_list').html(data[0]).sortable({helper:sortableHelper,handle:'.dockerhandle',items:'tr.sortable',cursor:'move',axis:'y',containment:'parent',cancel:'span.docker_readmore,input',delay:100,opacity:0.5,zIndex:9999,
     update:function(e,ui){
       var row = $('#docker_list').find('tr:first');
       var names = ''; var index = '';

--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -142,7 +142,7 @@ foreach ($containers as $ct) {
   echo "<td><input type='checkbox' id='$id-auto' class='autostart' container='".htmlspecialchars($name)."'".($info['autostart'] ? ' checked':'').">";
   echo "<span id='$id-wait' style='float:right;display:none'>"._('wait')."<input class='wait' container='".htmlspecialchars($name)."' type='number' value='$wait' placeholder='0' title=\""._('seconds')."\"></span></td>";
   echo "<td><div style='white-space:nowrap'>".htmlspecialchars(str_replace('Up',_('Uptime').':',my_lang_log($ct['Status'])))."<div style='margin-top:4px'>"._('Created').": ".htmlspecialchars(my_lang_time($ct['Created']))."</div></div></td>";
-  echo "<td><span class='dockerhandle'><i class='fa fa-arrows-v'></i></td></tr>";
+  echo "<td><span class='dockerhandle'><i class='fa fa-arrows-v'></i></span></td></tr>";
 }
 foreach ($images as $image) {
   if (count($image['usedBy'])) continue;

--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -142,7 +142,7 @@ foreach ($containers as $ct) {
   echo "<td><input type='checkbox' id='$id-auto' class='autostart' container='".htmlspecialchars($name)."'".($info['autostart'] ? ' checked':'').">";
   echo "<span id='$id-wait' style='float:right;display:none'>"._('wait')."<input class='wait' container='".htmlspecialchars($name)."' type='number' value='$wait' placeholder='0' title=\""._('seconds')."\"></span></td>";
   echo "<td><div style='white-space:nowrap'>".htmlspecialchars(str_replace('Up',_('Uptime').':',my_lang_log($ct['Status'])))."<div style='margin-top:4px'>"._('Created').": ".htmlspecialchars(my_lang_time($ct['Created']))."</div></div></td>";
-	echo "<td><span class='dockerhandle'><i class='fa fa-arrows-v'></i></td></tr>";
+  echo "<td><span class='dockerhandle'><i class='fa fa-arrows-v'></i></td></tr>";
 }
 foreach ($images as $image) {
   if (count($image['usedBy'])) continue;

--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -141,7 +141,8 @@ foreach ($containers as $ct) {
   echo "<br><span class='mem-$id'>0 / 0</span></td>";
   echo "<td><input type='checkbox' id='$id-auto' class='autostart' container='".htmlspecialchars($name)."'".($info['autostart'] ? ' checked':'').">";
   echo "<span id='$id-wait' style='float:right;display:none'>"._('wait')."<input class='wait' container='".htmlspecialchars($name)."' type='number' value='$wait' placeholder='0' title=\""._('seconds')."\"></span></td>";
-  echo "<td><div style='white-space:nowrap'>".htmlspecialchars(str_replace('Up',_('Uptime').':',my_lang_log($ct['Status'])))."<div style='margin-top:4px'>"._('Created').": ".htmlspecialchars(my_lang_time($ct['Created']))."</div></div></td></tr>";
+  echo "<td><div style='white-space:nowrap'>".htmlspecialchars(str_replace('Up',_('Uptime').':',my_lang_log($ct['Status'])))."<div style='margin-top:4px'>"._('Created').": ".htmlspecialchars(my_lang_time($ct['Created']))."</div></div></td>";
+	echo "<td><span class='dockerhandle'><i class='fa fa-arrows-v'></i></td></tr>";
 }
 foreach ($images as $image) {
   if (count($image['usedBy'])) continue;

--- a/plugins/dynamix/DashStats.page
+++ b/plugins/dynamix/DashStats.page
@@ -160,6 +160,7 @@ div#iframe-popup{display:none;-webkit-overflow-scrolling:touch}
 div.last{padding-bottom:12px}
 div.left{float:left;width:66%;margin-top:-12px}
 div.right{float:right;margin:-20px 0 0 0;text-align:center}
+.section,.next{cursor:grab}
 span.ctrl{float:right;margin-right:10px}
 span.outer{float:left}
 span.inner{width:<?=$theme1?153:140?>px}
@@ -1007,7 +1008,7 @@ var sortableHelper = function(e,ui){
   return ui;
 };
 $(function() {
-  $('table').sortable({helper:sortableHelper,items:'.sortable',cursor:'move',axis:'y',containment:'parent',delay:100,opacity:0.5,zIndex:9999,
+  $('table').sortable({helper:sortableHelper,items:'.sortable',handle:'.section,.next',cursor:'move',axis:'y',containment:'parent',delay:100,opacity:0.5,zIndex:9999,
   update:function(e,ui){
     var table = ui.item.parent();
     var index = [], prev = -1;


### PR DESCRIPTION
Since Santa got me an (ugh) iPad figured I'd fix https://forums.unraid.net/topic/84824-docker-tab-not-scrolling-on-ipad/?tab=comments#comment-931502

The big difference is that on the dashboard you can only drag to rearrange from each section's title bar, and on the docker tab only from the new up/down arrow on the right.  This fixes the not able to scroll on iPad devices either of the pages.  

You still can't rearrange either of the displays from either Android or iOS, but no one is complaining about that (and you couldn't do it previously either)