### PR TITLE
fix: login prompt when switching between servers

### DIFF
--- a/plugins/dynamix/include/local_prepend.php
+++ b/plugins/dynamix/include/local_prepend.php
@@ -24,7 +24,8 @@ setlocale(LC_ALL,'en_US.UTF-8');
 date_default_timezone_set(substr(readlink('/etc/localtime-copied-from'),20));
 ini_set("session.use_strict_mode", "1");
 session_name("unraid_".md5(strstr($_SERVER['HTTP_HOST'].':', ':', true)));
-session_set_cookie_params(0, '/; samesite=strict', null, array_key_exists('HTTPS', $_SERVER), true);
+$secure = array_key_exists('HTTPS', $_SERVER);
+session_set_cookie_params(0, '/; samesite='.$secure?'strict':'lax', null, $secure, true);
 if ($_SERVER['SCRIPT_NAME'] != '/login.php' && $_SERVER['SCRIPT_NAME'] != '/auth_request.php' && isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!isset($var)) $var = parse_ini_file('state/var.ini');
     if (!isset($var['csrf_token'])) csrf_terminate("uninitialized");


### PR DESCRIPTION
Sends "samesite=strict" when HTTPS is enabled and "samesite=lax" when it is not.  HTTPS users will have samesite protection and be able to switch between servers if they have the same domain name, while HTTP users will not have samesite protection but will still be able to switch between servers