### PR TITLE
Switch Diagnostics to web socket

### DIFF
--- a/plugins/dynamix/Diagnostics.page
+++ b/plugins/dynamix/Diagnostics.page
@@ -4,8 +4,8 @@ Icon="icon-diagnostics"
 Tag="tv"
 ---
 <?PHP
-/* Copyright 2005-2020, Lime Technology
- * Copyright 2012-2020, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,

--- a/plugins/dynamix/Diagnostics.page
+++ b/plugins/dynamix/Diagnostics.page
@@ -26,6 +26,7 @@ pre>p{margin:0;padding:0}
 
 <script>
 var diagnosticsFile = "";
+var file = "";
 var diagnostic = new NchanSubscriber('/sub/diagnostic');
 diagnostic.on('message',function(data) {
   if (data) {
@@ -33,11 +34,20 @@ diagnostic.on('message',function(data) {
       diagnostic.stop();
       swal.close();
       location = diagnosticsFile;
+      setTimeout(function(){cleanUp(file);},4000);
     } else {
       $("#command").html(data);
     }
   }
 });
+
+function cleanUp(file) {	
+  if (document.hasFocus()) {	
+    $.post('/webGui/include/Download.php',{cmd:'delete',file:file});	
+  } else {	
+    setTimeout(function(){cleanUp(file);},2000);	
+  }	
+}
 
 function zipfile(){
   var tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds

--- a/plugins/dynamix/Diagnostics.page
+++ b/plugins/dynamix/Diagnostics.page
@@ -25,29 +25,40 @@ pre>p{margin:0;padding:0}
 </style>
 
 <script>
+var diagnosticsFile = "";
+var diagnostic = new NchanSubscriber('/sub/diagnostic');
+diagnostic.on('message',function(data) {
+  if (data) {
+    if (data == diagnosticsFile.replace("/","")+"FINISHED") {
+      diagnostic.stop();
+      swal.close();
+      location = diagnosticsFile;
+    } else {
+      $("#command").html(data);
+    }
+  }
+});
+
 function zipfile(){
   var tzoffset = (new Date()).getTimezoneOffset() * 60000; //offset in milliseconds
   var localISOTime = (new Date(Date.now() - tzoffset)).toISOString().slice(0, -1);
   return '<?=$zip?>-diagnostics-'+localISOTime.substr(0,16).replace(/[-:]/g,'').replace('T','-')+'.zip';
 }
-function cleanUp(file) {
-  if (document.hasFocus()) {
-    $('input[value="Downloading..."]').val('Download').prop('disabled',false);
-    $('div.spinner').hide('slow');
-    $('#pleaseWait').hide('slow');
-    $.post('/webGui/include/Download.php',{cmd:'delete',file:file});
-  } else {
-    setTimeout(function(){cleanUp(file);},2000);
-  }
-}
+
 function diagnostics(file) {
-  $('input[value="Download"]').val('Downloading...').prop('disabled',true);
-  $('div.spinner').show('slow');
-  $('#pleaseWait').show('slow');
   var anonymize = $('#anonymize').is(':checked') ? '' : '-a';
   $.post('/webGui/include/Download.php',{cmd:'diag',file:file,anonymize:anonymize},function(zip) {
-    location = zip;
-    setTimeout(function(){cleanUp(file);},4000);
+    diagnosticsFile = zip;
+    diagnostic.start();
+    swal({
+      title: "_(Downloading...)_",
+      text: "/boot/logs"+zip+"<br><tt><span id='command'></span></tt>",
+      allowOutsideClick: false,
+      showConfirmButton: false,
+      showCancelButton: false,
+      type: "info",
+      html: true
+    });
   });
 }
 </script>
@@ -94,3 +105,5 @@ to the system log.*
 :end
 
 <input type="button" value="_(Download)_" onclick="diagnostics(zipfile())"><input type="button" value="_(Done)_" onclick="done()"><input type="checkbox" id="anonymize" checked>_(Anonymize diagnostics)_
+
+

--- a/plugins/dynamix/include/Download.php
+++ b/plugins/dynamix/include/Download.php
@@ -1,6 +1,6 @@
 <?PHP
-/* Copyright 2005-2020, Lime Technology
- * Copyright 2012-2020, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,

--- a/plugins/dynamix/include/Download.php
+++ b/plugins/dynamix/include/Download.php
@@ -34,7 +34,7 @@ case 'delete':
 case 'diag':
   if (is_file("$docroot/$file") && strpos(realpath("$docroot/$file"), $docroot.'/') !== 0) exit;
   $anon = empty($_POST['anonymize']) ? '' : escapeshellarg($_POST['anonymize']);
-  exec("echo $docroot/webGui/scripts/diagnostics $anon ".escapeshellarg("$docroot/$file")." | at NOW -m > /dev/null 2>&1");
+  exec("echo $docroot/webGui/scripts/diagnostics $anon ".escapeshellarg("$docroot/$file")." | at NOW > /dev/null 2>&1");
   echo "/$file";
   break;
 case 'unlink':

--- a/plugins/dynamix/include/Download.php
+++ b/plugins/dynamix/include/Download.php
@@ -34,7 +34,7 @@ case 'delete':
 case 'diag':
   if (is_file("$docroot/$file") && strpos(realpath("$docroot/$file"), $docroot.'/') !== 0) exit;
   $anon = empty($_POST['anonymize']) ? '' : escapeshellarg($_POST['anonymize']);
-  exec("$docroot/webGui/scripts/diagnostics $anon ".escapeshellarg("$docroot/$file"));
+  exec("echo $docroot/webGui/scripts/diagnostics $anon ".escapeshellarg("$docroot/$file")." | at NOW -m > /dev/null 2>&1");
   echo "/$file";
   break;
 case 'unlink':

--- a/plugins/dynamix/scripts/diagnostics
+++ b/plugins/dynamix/scripts/diagnostics
@@ -1,7 +1,7 @@
 #!/usr/bin/php -q
 <?PHP
-/* Copyright 2005-2019, Lime Technology
- * Copyright 2012-2019, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,

--- a/plugins/dynamix/scripts/diagnostics
+++ b/plugins/dynamix/scripts/diagnostics
@@ -1,7 +1,7 @@
 #!/usr/bin/php -q
 <?PHP
-/* Copyright 2005-2021, Lime Technology
- * Copyright 2012-2021, Bergware International.
+/* Copyright 2005-2019, Lime Technology
+ * Copyright 2012-2019, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,
@@ -22,11 +22,29 @@ $var = (array)@parse_ini_file("$get/var.ini");
 $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
 $folders = ['/boot','/boot/config','/boot/config/plugins','/boot/extra','/boot/syslinux','/var/log','/var/log/plugins','/var/log/packages','/tmp'];
 
+function curl_socket($socket, $url, $postdata = NULL) {
+  $ch = curl_init($url);
+  curl_setopt($ch, CURLOPT_UNIX_SOCKET_PATH, $socket);
+  if ($postdata !== NULL) {
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $postdata);
+  }
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+  curl_exec($ch);
+  curl_close($ch);
+}
+function publish($endpoint, $message){
+  curl_socket("/var/run/nginx.socket", "http://localhost/pub/$endpoint?buffer_length=1", $message);
+}
+
 function exert($cmd, &$save=null) {
+  global $cli,$diag;
 // execute command with timeout of 30s
+  publish("diagnostic",$cmd);
   exec("timeout -s9 30 $cmd", $save);
   return implode("\n",$save);
 }
+
 function shareDisks($share) {
   return exec("shopt -s dotglob; getfattr --no-dereference --absolute-names --only-values -n system.LOCATIONS ".escapeshellarg("/usr/local/emhttp/mnt/user/$share")." 2>/dev/null") ?: "no drives";
 }
@@ -301,5 +319,10 @@ if (file_exists($vfiopci)) {
 }
 // create resulting zip file and remove temp folder
 exert("zip -qmr ".escapeshellarg($zip)." ".escapeshellarg("/$diag"));
-if ($cli) echo "done.\nZIP file '$zip' created.\n";
+if ($cli) {
+  echo "done.\nZIP file '$zip' created.\n";
+} else {
+  copy($zip,"/boot/logs/".basename($zip));
+}
+publish("diagnostic",basename($zip)."FINISHED");
 ?>


### PR DESCRIPTION
Switches diagnostics to run via a Web Socket

- Will eliminate the fairly common timeouts prevalent, especially with wide arrays and drives spun down
- If a command crashes, it's helpful to the forum to know exactly where it hung up
- Even if the web socket isn't working (browser issues), the file is now also saved to the flash drive.
- Safeguards in place to handle if the user runs multiple diagnostics at the same time.