### PR TITLE
Protect GUI from invalid .page files

### DIFF
--- a/plugins/dynamix/include/PageBuilder.php
+++ b/plugins/dynamix/include/PageBuilder.php
@@ -31,7 +31,8 @@ function build_pages($pattern) {
   global $site;
   foreach (glob($pattern,GLOB_NOSORT) as $entry) {
     [$header, $content] = explode("---\n", file_get_contents($entry),2);
-    $page = parse_ini_string($header);
+    $page = @parse_ini_string($header);
+    if ( ! $page ) exec("logger -t 'webGUI' Invalid .page format: $entry");
     $page['file'] = $entry;
     $page['root'] = dirname($entry);
     $page['name'] = basename($entry, '.page');


### PR DESCRIPTION
If the format of the .page is completely wrong, then every page gets corrupted, and the system becomes unusable.  Personally, I hate it that every .page file can potentially take down the entire GUI in case of an error.  Blocking the output of the parse_ini_file protects the GUI, and the file gets logged to inform the user / forum.

Realistically, a released plugin should never trigger this code, but it's really annoying when it does (https://forums.unraid.net/bug-reports/stable-releases/gui-partially-didnt-working-r1327/) as it's not obvious anywhere what plugin is causing it.