### PR TITLE
Fix missing CSRF when deleting pool

### DIFF
--- a/plugins/dynamix/DeviceInfo.page
+++ b/plugins/dynamix/DeviceInfo.page
@@ -791,4 +791,5 @@ _(Name)_:
 <input type="hidden" name="changeSlots" value="apply">
 <input type="hidden" name="poolName" value="<?=$name?>">
 <input type="hidden" name="poolSlots" value="0">
+<input type='hidden' name='csrf_token' value='<?=$var['csrf_token']?>'>
 </form>


### PR DESCRIPTION
https://forums.unraid.net/bug-reports/stable-releases/691-unable-to-delete-new-pool-emhttpd-error-changeslots-missing-csrf_token-r1361/