### PR TITLE
WIP: Use WebUI with dynamic/static configuration

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -299,7 +299,7 @@ class DockerTemplates {
 			if ($ct['Running']) {
 				$port = &$ct['Ports'][0];
 				$ip = ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : $port['IP']);
-				$tmp['url'] = $ip ? (strpos($tmp['url'],$ip)!==false ? $tmp['url'] : $this->getControlURL($ct, $ip)) : $tmp['url'];
+				$tmp['url'] = $tmp['url'] ?? $this->getControlURL($ct, $ip);
 				$tmp['shell'] = $tmp['shell'] ?? $this->getTemplateValue($image, 'Shell');
 			}
 			$tmp['registry'] = $tmp['registry'] ?? $this->getTemplateValue($image, 'Registry');


### PR DESCRIPTION
WebUI configuration with a dynamic or static value.

Tested with:
* without configuration => webui isn't displayed
* with configuration:
  * `http://[IP]:[PORT:8080]/test` is ok
  * `http://example.com` is ok
  * `http://192.169.4.3` is ok