### PR TITLE
Prevent autofilling of passwords on containers/vms

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -345,6 +345,7 @@ function makeConfig(opts) {
     value.addClass("numbersOnly");
   }
   if (opts.Mask == "true") {
+    value.prop("autocomplete","new-password");
     value.prop("type", "password");
   }
   return newConfig.prop('outerHTML');

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -871,7 +871,7 @@
 			</tr>
 			<tr class="vncpassword">
 				<td>_(VNC Password)_:</td>
-				<td><input type="password" name="domain[password]" title="_(password for VNC)_" placeholder="_(password for VNC)_ (_(optional)_)" /></td>
+				<td><input type="password" name="domain[password]" autocomplete='new-password' title="_(password for VNC)_" placeholder="_(password for VNC)_ (_(optional)_)" /></td>
 			</tr>
 			<tr class="<?if ($arrGPU['id'] != 'vnc') echo 'was';?>advanced vnckeymap">
 				<td>_(VNC Keyboard)_:</td>


### PR DESCRIPTION
Chrome / Firefox have very strange results when autofilling on containers:  Fixed IP will get "root" and the first password entry will have the root password.

Editing VMs have a share filled out of "root" and the VNC password of root password.