### PR TITLE
Include links in email and Discord agent notifications

### DIFF
--- a/plugins/dynamix/NotificationAgents.page
+++ b/plugins/dynamix/NotificationAgents.page
@@ -76,7 +76,6 @@ function testService(name) {
   form.append('<input type="hidden" name="#env[]" value="SUBJECT='+name+' test.">');
   form.append('<input type="hidden" name="#env[]" value="DESCRIPTION='+name+' test.">');
   form.append('<input type="hidden" name="#env[]" value="IMPORTANCE=normal">');
-  // note: not all agents will process the LINK parameter
   // host is normally added to link by the notify script. add it here since calling the agent directly.
   form.append('<input type="hidden" name="#env[]" value="LINK='+window.location.origin+'/Settings/Notifications">');
   form.submit();
@@ -91,7 +90,7 @@ function initDropdown() {
 <input type="hidden" name="#arg[2]" value="">
 </form>
 <?
-$fields = ['Event','Subject','Timestamp','Description','Importance','Content'];
+$fields = ['Event','Subject','Timestamp','Description','Importance','Content','Link'];
 $xml_file = "webGui/include/NotificationAgents.xml";
 $xml = @simplexml_load_file($xml_file) or die(_("Failed to open")." $xml_file");
 foreach ($xml->Agent as $agent) {

--- a/plugins/dynamix/NotificationAgents.page
+++ b/plugins/dynamix/NotificationAgents.page
@@ -3,8 +3,8 @@ Title="Notification Agents"
 Tag="rss-square"
 ---
 <?PHP
-/* Copyright 2005-2020, Lime Technology
- * Copyright 2012-2020, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,
@@ -76,6 +76,9 @@ function testService(name) {
   form.append('<input type="hidden" name="#env[]" value="SUBJECT='+name+' test.">');
   form.append('<input type="hidden" name="#env[]" value="DESCRIPTION='+name+' test.">');
   form.append('<input type="hidden" name="#env[]" value="IMPORTANCE=normal">');
+  // note: not all agents will process the LINK parameter
+  // host is normally added to link by the notify script. add it here since calling the agent directly.
+  form.append('<input type="hidden" name="#env[]" value="LINK='+window.location.origin+'/Settings/Notifications">');
   form.submit();
 }
 function initDropdown() {

--- a/plugins/dynamix/include/NotificationAgents.xml
+++ b/plugins/dynamix/include/NotificationAgents.xml
@@ -44,9 +44,9 @@
 # Quick test with default values:
 #   bash /boot/config/plugins/dynamix/notifications/agents/Discord.sh
 # Quick test with values set through environment (all vars are optional)
-#   EVENT="My Event" SUBJECT="My Subject" DESCRIPTION="My Description" CONTENT="My Message" IMPORTANCE="alert" bash /boot/config/plugins/dynamix/notifications/agents/Discord.sh
+#   EVENT="My Event" SUBJECT="My Subject" DESCRIPTION="My Description" CONTENT="My Message" IMPORTANCE="alert" LINK="/Dashboard" bash /boot/config/plugins/dynamix/notifications/agents/Discord.sh
 # Full test of notification system (at least one param is required)
-#   /usr/local/emhttp/webGui/scripts/notify -e "My Event" -s "My Subject" -d "My Description"  -m "My Message" -i "alert"
+#   /usr/local/emhttp/webGui/scripts/notify -e "My Event" -s "My Subject" -d "My Description"  -m "My Message" -i "alert" -l "/Dashboard"
 #
 # If a notification does not go through, check the /var/log/notify_Discord file for hints
 ############
@@ -61,6 +61,7 @@
 # SUBJECT (notify -s)
 # DESCRIPTION (notify -d)
 # CONTENT (notify -m)
+# LINK (notify -l)
 # TIMESTAMP (seconds from epoch)
 
 SCRIPTNAME=$(basename "$0")
@@ -72,6 +73,7 @@ LOG="/var/log/notify_${SCRIPTNAME%.*}"
 [[ -z "${DESCRIPTION}" ]] && DESCRIPTION='No description'
 [[ -z "${IMPORTANCE}" ]] && IMPORTANCE='normal'
 [[ -z "${TIMESTAMP}" ]] && TIMESTAMP=$(date +%s)
+[[ -n "${LINK}" ]] && [[ ${LINK} != http* ]] && LINK=$(</var/run/nginx.origin)${LINK}
 # note: there is no default for CONTENT
 
 # send DESCRIPTION and/or CONTENT. Ignore the default DESCRIPTION.
@@ -147,6 +149,10 @@ esac
 # if SERVER_ICON is defined, use it
 [[ -n "${SERVER_ICON}" && "${SERVER_ICON:0:8}" == "https://" ]] && ICON_URL="\"icon_url\": \"${SERVER_ICON}\","
 
+# https://birdie0.github.io/discord-webhooks-guide/structure/embed/url.html
+# if LINK is defined, use it
+[[ -n "${LINK}" ]] && LINK_URL="\"url\": \"${LINK}\","
+
 DATA=$(
   cat <<EOF
 {
@@ -155,6 +161,7 @@ DATA=$(
     {
       "title": "${EVENT:0:256}",
       "description": "${SUBJECT:0:2043}",
+      ${LINK_URL}
       "timestamp": ${FORMATTED_TIMESTAMP},
       "color": "${COLOR}",
       "author": {

--- a/plugins/dynamix/include/SMTPtest.php
+++ b/plugins/dynamix/include/SMTPtest.php
@@ -1,6 +1,6 @@
 <?PHP
-/* Copyright 2005-2020, Lime Technology
- * Copyright 2012-2020, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License version 2,
@@ -36,7 +36,7 @@ function PsEnded($pid) {
 function PsKill($pid) {
   exec("kill -9 $pid");
 }
-if (PsExecute("$docroot/webGui/scripts/notify -s 'Unraid SMTP Test' -d 'Test message received!' -i 'alert' -t")) {
+if (PsExecute("$docroot/webGui/scripts/notify -s 'Unraid SMTP Test' -d 'Test message received!' -i 'alert' -l '/Settings/Notifications' -t")) {
   $result = exec("tail -3 /var/log/syslog|awk '/sSMTP/ {getline;print}'|cut -d']' -f2|cut -d'(' -f1");
   $color = strpos($result, 'Sent mail') ? 'green' : 'red';
   echo _("Test result")."<span class='$color'>$result</span>";

--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -1,7 +1,7 @@
 #!/usr/bin/php -q
 <?PHP
-/* Copyright 2005-2020, Lime Technology
- * Copyright 2012-2020, Bergware International.
+/* Copyright 2005-2021, Lime Technology
+ * Copyright 2012-2021, Bergware International.
  * Copyright 2012, Andrew Hamer-Adams, http://www.pixeleyes.co.nz.
  *
  * This program is free software; you can redistribute it and/or
@@ -49,7 +49,7 @@ EOT;
   return 1;
 }
 
-function generate_email($event, $subject, $description, $importance, $message, $recipients) {
+function generate_email($event, $subject, $description, $importance, $message, $recipients, $fqdnlink) {
   global $ssmtp;
 
   $rcpt = $ssmtp['RcptTo'];
@@ -74,6 +74,11 @@ function generate_email($event, $subject, $description, $importance, $message, $
   $headers[] = "";
 
   $body      = [];
+  if (!empty($fqdnlink)) {
+    $body[]  = "Link: $fqdnlink";
+    $body[]  = "      (Note: if clicking link requires reauthentication, copy/paste instead)";
+    $body[]  = "";
+  }
   $body[]    = "Event: $event";
   $body[]    = "Subject: $subject";
   $body[]    = "Description: $description";
@@ -167,6 +172,7 @@ case 'add':
   $ticket = $timestamp;
   $mailtest = false;
   $overrule = false;
+  $host = rtrim(file_get_contents("/var/run/nginx.origin"));
 
   $options = getopt("l:e:s:d:i:m:r:xtb");
   foreach ($options as $option => $value) {
@@ -201,18 +207,19 @@ case 'add':
       break;
      case 'l':
       $link = $value;
+      $fqdnlink = (strpos($link,"http") === 0) ? $link : $host.$link;
       break;
     }
   }
-	
+
   $unread = "{$unread}/".safe_filename("{$event}-{$ticket}.notify");
   $archive = "{$archive}/".safe_filename("{$event}-{$ticket}.notify");
   if (file_exists($archive)) break;
   $entity = $overrule===false ? $notify[$importance] : $overrule;
   if (!$mailtest) file_put_contents($archive,"timestamp=$timestamp\nevent=$event\nsubject=$subject\ndescription=$description\nimportance=$importance\n".($message ? "message=".str_replace('\n','<br>',$message)."\n" : ""));
   if (($entity & 1)==1 && !$mailtest && !$noBrowser) file_put_contents($unread,"timestamp=$timestamp\nevent=$event\nsubject=$subject\ndescription=$description\nimportance=$importance\nlink=$link\n");
-  if (($entity & 2)==2 || $mailtest)  if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message, $recipients)) exit(1);
-  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg($subject)." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." bash ".$agent);};}};
+  if (($entity & 2)==2 || $mailtest)  if (!generate_email($event, $subject, str_replace('<br>','. ',$description), $importance, $message, $recipients, $fqdnlink)) exit(1);
+  if (($entity & 4)==4 && !$mailtest) { if (is_array($agents)) {foreach ($agents as $agent) {exec("TIMESTAMP='$timestamp' EVENT=".escapeshellarg($event)." SUBJECT=".escapeshellarg($subject)." DESCRIPTION=".escapeshellarg($description)." IMPORTANCE=".escapeshellarg($importance)." CONTENT=".escapeshellarg($message)." LINK=".escapeshellarg($fqdnlink)." bash ".$agent);};}};
   break;
 
 case 'get':


### PR DESCRIPTION
Users with the Discord agent currently installed will need to go to the Notification Agents page, make a small change to the Discord agent, and hit Apply to regenerate the script.

Note: When clicking links from web-based email clients you will likely be redirected to the login screen due to SameSite cookie restrictions. Links can be copy/pasted to the address bar instead.