### PR TITLE
Revert "dockerMan: Selectable start upon install"

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -113,14 +113,13 @@ if (isset($_POST['contName'])) {
       goto END;
     }
   }
-  $startContainer = filter_var($_POST['contStart'],FILTER_VALIDATE_BOOLEAN);
+  $startContainer = true;
   // Remove existing container
   if ($DockerClient->doesContainerExist($Name)) {
     // attempt graceful stop of container first
     $oldContainerInfo = $DockerClient->getContainerDetails($Name);
     if (!empty($oldContainerInfo) && !empty($oldContainerInfo['State']) && !empty($oldContainerInfo['State']['Running'])) {
       // attempt graceful stop of container first
-      $startContainer = true;
       stopContainer($Name);
     }
     // force kill container if still running after 10 seconds
@@ -881,15 +880,9 @@ _(Privileged)_:
 &nbsp;
 : <a href="javascript:addConfigPopup()"><i class="fa fa-fw fa-plus"></i> _(Add another Path, Port, Variable, Label or Device)_</a>
 
-<?if ($xmlType != "edit"):?>
-&nbsp;
-: <input type='checkbox' name='contStart' checked> <span class='orange-text'>_(Start Container After Install)_</span>
-<?endif;?>
-
 &nbsp;
 : <input type="submit" value="<?=$xmlType=='edit' ? "_(Apply)_" : " _(Apply)_ "?>"><input type="button" value="_(Done)_" onclick="done()">
   <?if ($authoringMode):?><button type="submit" name="dryRun" value="true" onclick="$('*[required]').prop('required', null);">_(Save)_</button><?endif;?>
-
 
 </form>
 </div>
@@ -1053,7 +1046,7 @@ function load_contOverview() {
     // Handle code block being created by authors indenting (manually editing the xml and spacing)
     new_overview = new_overview.replaceAll("    ","&nbsp;&nbsp;&nbsp;&nbsp;");
     new_overview = marked(new_overview);
-  } else
+  } else 
     new_overview = new_overview.replaceAll("\n","");
   $("#contDescription").html(new_overview);
 }


### PR DESCRIPTION
Reverts limetech/webgui#782

Fatal flaw in the logic.  If an already installed container fails to start due to an error in the docker run command (eg: port already in use, nvidia problems etc), it's impossible to see the docker run command.  Need to rethink