### PR TITLE
Notification links will point to http://tower.local

### DIFF
--- a/plugins/dynamix/include/NotificationAgents.xml
+++ b/plugins/dynamix/include/NotificationAgents.xml
@@ -73,7 +73,16 @@ LOG="/var/log/notify_${SCRIPTNAME%.*}"
 [[ -z "${DESCRIPTION}" ]] && DESCRIPTION='No description'
 [[ -z "${IMPORTANCE}" ]] && IMPORTANCE='normal'
 [[ -z "${TIMESTAMP}" ]] && TIMESTAMP=$(date +%s)
-[[ -n "${LINK}" ]] && [[ ${LINK} != http* ]] && LINK=$(</var/run/nginx.origin)${LINK}
+# ensure link has a host
+if [[ -n "${LINK}" ]] && [[ ${LINK} != http* ]]; then
+source <(grep "NAME\|LOCAL_TLD\|PORT" /usr/local/emhttp/state/var.ini 2>/dev/null)
+HOST_NAME=${NAME,,}
+[[ -n ${LOCAL_TLD} ]] && LOCAL_TLD=".${LOCAL_TLD,,}"
+[[ "${PORT}" = "80" ]] && PORT=
+[[ -n ${PORT} ]] && PORT=":${PORT}"
+HOST="http://${HOST_NAME}${LOCAL_TLD}${PORT}"
+LINK=${HOST}${LINK}
+fi
 # note: there is no default for CONTENT
 
 # send DESCRIPTION and/or CONTENT. Ignore the default DESCRIPTION.

--- a/plugins/dynamix/scripts/notify
+++ b/plugins/dynamix/scripts/notify
@@ -172,8 +172,13 @@ case 'add':
   $ticket = $timestamp;
   $mailtest = false;
   $overrule = false;
-  $host = rtrim(file_get_contents("/var/run/nginx.origin"));
-
+  
+  $var = parse_ini_file('/var/local/emhttp/var.ini');
+  $host_name = strtolower($var['NAME']);
+  $host_tld = $var['LOCAL_TLD'] ? strtolower(".{$var['LOCAL_TLD']}") : "";
+  $host_port = $var['PORT'] != 80 ? ":{$var['PORT']}" : "";
+  $host = "http://{$host_name}{$host_tld}{$host_port}";
+  
   $options = getopt("l:e:s:d:i:m:r:xtb");
   foreach ($options as $option => $value) {
     switch ($option) {


### PR DESCRIPTION
6.10 removes /var/run/nginx.origin, need to build links to http://tower.local
Redirects will forward user to a better url if one is available.