### PR TITLE
When viewing source, identify which .page file is responsible

### DIFF
--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -534,6 +534,7 @@ unset($pages,$page,$pgs,$pg,$icon,$nchan,$running,$start,$stop,$row,$script,$opt
 <iframe id="progressFrame" name="progressFrame" frameborder="0"></iframe>
 <?
 // Build footer
+echo "\n<!--\n".str_repeat("#",30)."\n Footer\n".str_repeat("#",30)."\n-->\n";
 echo '<div id="footer"><span id="statusraid"><span id="statusbar">';
 $progress = ($var['fsProgress']!='')? "&bullet;<span class='blue strong'>{$var['fsProgress']}</span>" : '';
 switch ($var['fsState']) {

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -421,7 +421,7 @@ if ($display['usage']) my_usage();
 echo "</div>";
 echo "<div id='nav-right'>";
 foreach ($buttons as $button) {
-  eval("?> \n<!--\n".str_repeat("#",30)."\n Button: {$button['file']}\n".str_repeat("#",30)."\n-->\n");
+  echo "\n<!--\n".str_repeat("#",30)."\n {$button['file']}\n".str_repeat("#",30)."\n-->\n";
   eval('?>'.parse_text($button['text']));
   if (empty($button['Link'])) {
     $icon = $button['Icon'];
@@ -502,7 +502,7 @@ foreach ($pages as $page) {
   }
   // create list of nchan scripts to be started
   if (isset($page['Nchan'])) nchan_merge($page['root'], $page['Nchan']);
-  eval("?> \n<!--\n".str_repeat("#",30)."\n {$page['file']}\n".str_repeat("#",30)."\n-->\n");
+  echo "\n<!--\n".str_repeat("#",30)."\n {$page['file']}\n".str_repeat("#",30)."\n-->\n";
   empty($page['Markdown']) || $page['Markdown']=='true' ? eval('?>'.Markdown(parse_text($page['text']))) : eval('?>'.parse_text($page['text']));
   if ($close) echo "</div></div>";
 }

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -421,6 +421,7 @@ if ($display['usage']) my_usage();
 echo "</div>";
 echo "<div id='nav-right'>";
 foreach ($buttons as $button) {
+  eval("?> \n<!--\n".str_repeat("#",30)."\n {$button['file']}\n".str_repeat("#",30)."\n-->\n");
   eval('?>'.parse_text($button['text']));
   if (empty($button['Link'])) {
     $icon = $button['Icon'];
@@ -501,6 +502,7 @@ foreach ($pages as $page) {
   }
   // create list of nchan scripts to be started
   if (isset($page['Nchan'])) nchan_merge($page['root'], $page['Nchan']);
+  eval("?> \n<!--\n".str_repeat("#",30)."\n {$page['file']}\n".str_repeat("#",30)."\n-->\n");
   empty($page['Markdown']) || $page['Markdown']=='true' ? eval('?>'.Markdown(parse_text($page['text']))) : eval('?>'.parse_text($page['text']));
   if ($close) echo "</div></div>";
 }

--- a/plugins/dynamix/include/DefaultPageLayout.php
+++ b/plugins/dynamix/include/DefaultPageLayout.php
@@ -421,7 +421,7 @@ if ($display['usage']) my_usage();
 echo "</div>";
 echo "<div id='nav-right'>";
 foreach ($buttons as $button) {
-  eval("?> \n<!--\n".str_repeat("#",30)."\n {$button['file']}\n".str_repeat("#",30)."\n-->\n");
+  eval("?> \n<!--\n".str_repeat("#",30)."\n Button: {$button['file']}\n".str_repeat("#",30)."\n-->\n");
   eval('?>'.parse_text($button['text']));
   if (empty($button['Link'])) {
     $icon = $button['Icon'];


### PR DESCRIPTION
Up to @bergware.  As an example, I had no idea that UD injected code into every page of the UI.