### PR TITLE
Docker: Only save templates as v2

### DIFF
--- a/plugins/dynamix.docker.manager/include/Helpers.php
+++ b/plugins/dynamix.docker.manager/include/Helpers.php
@@ -47,14 +47,6 @@ function postToXML($post, $setOwnership=false) {
   $xml->DonateLink         = xml_encode($post['contDonateLink']);
   $xml->Requires           = xml_encode($post['contRequires']);
 
-  // V1 compatibility
-  $xml->Description        = xml_encode($post['contOverview']);
-  $xml->Networking->Mode   = xml_encode($post['contNetwork']);
-  $xml->Networking->addChild("Publish");
-  $xml->addChild("Data");
-  $xml->addChild("Environment");
-  $xml->addChild("Labels");
-
   $size = is_array($post['confName']) ? count($post['confName']) : 0;
   for ($i = 0; $i < $size; $i++) {
     $Type                  = $post['confType'][$i];
@@ -68,28 +60,6 @@ function postToXML($post, $setOwnership=false) {
     $config['Display']     = xml_encode($post['confDisplay'][$i]);
     $config['Required']    = xml_encode($post['confRequired'][$i]);
     $config['Mask']        = xml_encode($post['confMask'][$i]);
-    // V1 compatibility
-    if ($Type == 'Port') {
-      $port                = $xml->Networking->Publish->addChild("Port");
-      $port->HostPort      = $post['confValue'][$i];
-      $port->ContainerPort = $post['confTarget'][$i];
-      $port->Protocol      = $post['confMode'][$i];
-    } elseif ($Type == 'Path') {
-      $path                = $xml->Data->addChild("Volume");
-      $path->HostDir       = $post['confValue'][$i];
-      $path->ContainerDir  = $post['confTarget'][$i];
-      $path->Mode          = $post['confMode'][$i];
-    } elseif ($Type == 'Variable') {
-      $variable            = $xml->Environment->addChild("Variable");
-      $variable->Value     = $post['confValue'][$i];
-      $variable->Name      = $post['confTarget'][$i];
-      $variable->Mode      = $post['confMode'][$i];
-    } elseif ($Type == 'Label') {
-      $label               = $xml->Labels->addChild("Label");
-      $label->Value        = $post['confValue'][$i];
-      $label->Name         = $post['confTarget'][$i];
-      $label->Mode         = $post['confMode'][$i];
-    }
   }
   $dom = new DOMDocument('1.0');
   $dom->preserveWhiteSpace = false;


### PR DESCRIPTION
This drops compatibility with newly created templates being installed on 6.0 / 6.1  It does not drop compatibility with installing templates created on 6.0 / 6.1 when on 6.2+

Basically it just removes the redundant entries in the xml