### PR TITLE
Silence PHP error on syslinux page if flash drive is missing

### DIFF
--- a/plugins/dynamix/Syslinux.page
+++ b/plugins/dynamix/Syslinux.page
@@ -21,7 +21,7 @@ function strip($area) {
   return preg_replace(["/^|(\n)  /","/\n$/"],["$1",""],$area);
 }
 $file    = '/boot/syslinux/syslinux.cfg';
-$current = file_get_contents($file);
+$current = @file_get_contents($file);
 $default = @file_get_contents("$file-") ?: $current;
 $current = preg_replace(["/\r\n/","/\r/","/\n$/"],["\n","\n",""],$current);
 $default = preg_replace(["/\r\n/","/\r/","/\n$/"],["\n","\n",""],$default);


### PR DESCRIPTION
While this case isn't explicitly covered by the banner warning (no syslinux.cfg file), if this file is missing / corrupted then the system probably won't boot if the flash drive is still present.   I told JonP as I run across PHP errors in the WebUI I'd put in code to silence them or handle them as applicable.