### PR TITLE
UpdateDNS servercomment and internalip tweaks

### DIFF
--- a/plugins/dynamix/include/UpdateDNS.php
+++ b/plugins/dynamix/include/UpdateDNS.php
@@ -64,9 +64,11 @@ $internalip = ipaddr($ethX);
 // build post array
 $post = [
   'plgversion' => 'base-'.$var['version'],
-  'internalip' => is_array($internalip) ? $internalip[0] : $internalip,
   'keyfile' => $keyfile
 ];
+if (preg_match('/.*\.unraid\.net$/', $certhostname)) {
+  $post['internalip'] = is_array($internalip) ? $internalip[0] : $internalip;
+}
 if ($isRegistered) {
   $post['servercomment'] = $var['COMMENT'];
 }


### PR DESCRIPTION
Bring the base UpdateDNS script more inline with the plugin's UpdateDNS, where it sends data under two conditions:
* either the system is signed in, in which case also send the 'servercomment' variable
* or SSL is enabled, in which case also send the 'internalip' variable
If both conditions are met, then both variables should be sent.