### PR TITLE
Re-add hidden donation links to docker templates

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -823,10 +823,14 @@ _(Docker Hub URL)_:
 
 </div>
 <div markdown="1" class="noshow"> <!-- Deprecated for author to enter or change, but needs to be present -->
-_(Template URL)_:
-: <input type="text" name="contTemplateURL">
+Donation Text:
+: <input type="text" name="contDonateText">
 
-:docker_client_template_url_help:
+Donation Link:
+: <input type="text" name="contDonateLink">
+
+Template URL:
+: <input type="text" name="contTemplateURL">
 
 </div>
 <div markdown="1" class="advanced">


### PR DESCRIPTION
Reverts https://github.com/limetech/webgui/pull/792 in order to support the CA pitch  (And should be reverted anyways for future capabilities)