### PR TITLE
feat: make libvirt networks accessible via gui

### DIFF
--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1494,11 +1494,16 @@ Open the folder for the version of Windows you are installing and then select th
 Three drivers will be found. Select them all, click next, and the vDisks you have assigned will appear.
 :end
 
-:vms_network_bridge_help:
-Select the name of the network bridge you wish to use as default for your VMs,
-the setting 'virbr0' will let libvirt create a virtual bridge that utilizes NAT (network address translation)
-and act as a DHCP server to hand out IP addresses to virtual machines directly.
-More optional selections are present when virtual bridges are created under network settings.
+:vms_network_source_help:
+Select the name of the network you wish to use as default for your VMs.
+You can choose between **'bridges'** created under network settings or
+**'libvirt'** created with virsh command in the terminal.
+The bridge **'virbr0'** and the associated virtual network **'default'** are
+created by libvirt.  
+Both utilizes NAT (network address translation) and act as a DHCP server to hand out IP addresses to virtual machines directly.
+More optional selections are present for bridges under network settings or for libvirt networks with the virsh command in the terminal.
+
+**If your are unsure, choose 'virbr0' as the recommended Unraid default.**
 
 NOTE: You can also specify a network bridge on a per-VM basis.
 :end

--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1507,8 +1507,8 @@ More optional selections are present for bridges under network settings or for l
 
 NOTE: You can also specify a network source on a per-VM basis.
 
-**IMPORTANT: Most LibVirt networks only become active as soon as the associated interface is up.  
-This can be ensured with an 'ip link set <ethx> up' at the beginning of the go file.**
+**IMPORTANT: Neither Libvirt nor Unraid automatically brings up an interface that is assigned to a Libvirt network.
+Before you use a Libvirt network, please go to Settings -> Network Settings and, if necessary, manually set the associated interface to up.**
 :end
 
 :vms_host_shutdown_help:

--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1505,7 +1505,10 @@ More optional selections are present for bridges under network settings or for l
 
 **If your are unsure, choose 'virbr0' as the recommended Unraid default.**
 
-NOTE: You can also specify a network bridge on a per-VM basis.
+NOTE: You can also specify a network source on a per-VM basis.
+
+**IMPORTANT: Most LibVirt networks only become active as soon as the associated interface is up.  
+This can be ensured with an 'ip link set <ethx> up' at the beginning of the go file.**
 :end
 
 :vms_host_shutdown_help:

--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -51,7 +51,7 @@ function detect(&$syslinux, $key) {
   return $value;
 }
 $syslinux          = file('/boot/syslinux/syslinux.cfg',FILE_IGNORE_NEW_LINES+FILE_SKIP_EMPTY_LINES);
-$arrValidBridges   = getNetworkBridges();
+$arrValidNetworks   = getValidNetworks();
 $pcie_acs_override = detect($syslinux, 'pcie_acs_override');
 $vfio_allow_unsafe = detect($syslinux, 'allow_unsafe_interrupts');
 $bgcolor           = strstr('white,azure',$display['theme']) ? '#f2f2f2' : '#1c1c1c';
@@ -169,12 +169,19 @@ _(Default Windows VirtIO driver ISO)_ (_(optional)_):
 :vms_virtio_driver_help:
 
 <div class="advanced" markdown="1">
-_(Default network bridge)_:
-: <select id="bridge" name="BRNAME">
-  <?foreach ($arrValidBridges as $strBridge) echo mk_option($domain_cfg['BRNAME'], $strBridge, $strBridge);?>
+_(Default network source)_:
+: <select id="network" name="BRNAME">
+  <?foreach (array_keys($arrValidNetworks) as $key) {
+
+    echo mk_option("", $key, "- ".$key." -", "disabled");
+
+    foreach ($arrValidNetworks[$key] as $strNetwork) {
+        echo mk_option($domain_cfg['BRNAME'], $strNetwork, $strNetwork);
+    }
+  }?>
   </select>
 
-:vms_network_bridge_help:
+:vms_network_source_help:
 
 _(Upon host shutdown)_:
 : <select id="hostshutdown" name="HOSTSHUTDOWN">
@@ -443,7 +450,7 @@ $(function(){
       $("#mediadir").prop("disabled", checked);
       $("#winvirtio_select").prop("disabled", checked);
       $("#winvirtio").prop("disabled", checked);
-      $("#bridge").prop("disabled", checked);
+      $("#network").prop("disabled", checked);
       $("#hostshutdown").prop("disabled", checked);
       $("#pcie_acs_override").prop("disabled", checked);
       $("#vm_shutdown_timeout").prop("disabled", checked);

--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -173,7 +173,7 @@ _(Default network source)_:
 : <select id="network" name="BRNAME">
   <?foreach (array_keys($arrValidNetworks) as $key) {
 
-    echo mk_option("", $key, "- ".$key." -", "disabled");
+    echo mk_option("", $key, "- "._($key)." -", "disabled");
 
     foreach ($arrValidNetworks[$key] as $strNetwork) {
         echo mk_option($domain_cfg['BRNAME'], $strNetwork, $strNetwork);

--- a/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -922,15 +922,18 @@
 
 		$arrValidNetworks['bridges'] = array_values($arrBridges);
 
-		$arrVirtual = $lv->libvirt_get_net_list($lv->get_connection());
+        // This breaks VMSettings.page if libvirt is not running
+        if ($libvirt_running == "yes") {
+		    $arrVirtual = $lv->libvirt_get_net_list($lv->get_connection());
 
-		if (($key = array_search('default', $arrVirtual)) !== false) {
-			unset($arrVirtual[$key]);
-		}
+		    if (($key = array_search('default', $arrVirtual)) !== false) {
+		    	unset($arrVirtual[$key]);
+		    }
 
-		array_unshift($arrVirtual, 'default');
+		    array_unshift($arrVirtual, 'default');
 
-		$arrValidNetworks['libvirt'] = array_values($arrVirtual);
+		    $arrValidNetworks['libvirt'] = array_values($arrVirtual);
+        }
 
 		return $arrValidNetworks;
 	}

--- a/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -922,18 +922,18 @@
 
 		$arrValidNetworks['bridges'] = array_values($arrBridges);
 
-        // This breaks VMSettings.page if libvirt is not running
-        if ($libvirt_running == "yes") {
-		    $arrVirtual = $lv->libvirt_get_net_list($lv->get_connection());
-
-		    if (($key = array_search('default', $arrVirtual)) !== false) {
-		    	unset($arrVirtual[$key]);
-		    }
-
-		    array_unshift($arrVirtual, 'default');
-
-		    $arrValidNetworks['libvirt'] = array_values($arrVirtual);
-        }
+		// This breaks VMSettings.page if libvirt is not running
+        	if ($libvirt_running == "yes") {
+			$arrVirtual = $lv->libvirt_get_net_list($lv->get_connection());
+			
+			if (($key = array_search('default', $arrVirtual)) !== false) {
+				unset($arrVirtual[$key]);
+			}
+			
+			array_unshift($arrVirtual, 'default');
+			
+			$arrValidNetworks['libvirt'] = array_values($arrVirtual);
+		}
 
 		return $arrValidNetworks;
 	}

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -1016,7 +1016,7 @@
 					<?
 					foreach (array_keys($arrValidNetworks) as $key) {
 
-						echo mk_option("", $key, "- ".$key." -", "disabled");
+						echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 						foreach ($arrValidNetworks[$key] as $strNetwork) {
 							echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
@@ -1078,7 +1078,7 @@
 					<?
 					foreach (array_keys($arrValidNetworks) as $key) {
 
-						echo mk_option("", $key, "- ".$key." -", "disabled");
+						echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 						foreach ($arrValidNetworks[$key] as $strNetwork) {
 							echo mk_option($domain_bridge, $strNetwork, $strNetwork);

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -32,7 +32,7 @@
 	$arrValidCdromBuses = getValidCdromBuses();
 	$arrValidVNCModels = getValidVNCModels();
 	$arrValidKeyMaps = getValidKeyMaps();
-	$arrValidBridges = getNetworkBridges();
+	$arrValidNetworks = getValidNetworks();
 	$strCPUModel = getHostCPUModel();
 
 	$arrConfigDefaults = [
@@ -1010,12 +1010,17 @@
 				</td>
 			</tr>
 			<tr class="advanced">
-				<td>_(Network Bridge)_:</td>
+				<td>_(Network Source)_:</td>
 				<td>
 					<select name="nic[<?=$i?>][network]">
 					<?
-					foreach ($arrValidBridges as $strBridge) {
-						echo mk_option($arrNic['network'], $strBridge, $strBridge);
+					foreach (array_keys($arrValidNetworks) as $key) {
+
+						echo mk_option("", $key, "- ".$key." -", "disabled");
+
+						foreach ($arrValidNetworks[$key] as $strNetwork) {
+							echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
+						}
 					}
 					?>
 					</select>
@@ -1044,8 +1049,8 @@
 				</p>
 
 				<p>
-					<b>Network Bridge</b><br>
-					The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network bridge to the host.
+					<b>Network Source</b><br>
+					The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network to the host.
 				</p>
 
 				<p>
@@ -1067,12 +1072,17 @@
 				</td>
 			</tr>
 			<tr class="advanced">
-				<td>_(Network Bridge)_:</td>
+				<td>_(Network Source)_:</td>
 				<td>
 					<select name="nic[{{INDEX}}][network]">
 					<?
-					foreach ($arrValidBridges as $strBridge) {
-						echo mk_option($domain_bridge, $strBridge, $strBridge);
+					foreach (array_keys($arrValidNetworks) as $key) {
+
+						echo mk_option("", $key, "- ".$key." -", "disabled");
+
+						foreach ($arrValidNetworks[$key] as $strNetwork) {
+							echo mk_option($domain_bridge, $strNetwork, $strNetwork);
+						}
 					}
 					?>
 					</select>

--- a/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
@@ -28,7 +28,7 @@
 	$arrValidOtherDevices = getValidOtherDevices();
 	$arrValidUSBDevices = getValidUSBDevices();
 	$arrValidDiskDrivers = getValidDiskDrivers();
-	$arrValidBridges = getNetworkBridges();
+	$arrValidNetworks = getValidNetworks();
 	$strCPUModel = getHostCPUModel();
 
 	// Read localpaths in from libreelec.cfg
@@ -827,12 +827,17 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</td>
 				</tr>
 				<tr class="advanced">
-					<td>_(Network Bridge)_:</td>
+					<td>_(Network Source)_:</td>
 					<td>
 						<select name="nic[<?=$i?>][network]">
 						<?
-						foreach ($arrValidBridges as $strBridge) {
-							echo mk_option($arrNic['network'], $strBridge, $strBridge);
+						foreach (array_keys($arrValidNetworks) as $key) {
+
+							echo mk_option("", $key, "- ".$key." -", "disabled");
+
+							foreach ($arrValidNetworks as $strNetwork) {
+								echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
+							}
 						}
 						?>
 						</select>
@@ -859,8 +864,8 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</p>
 
 					<p>
-						<b>Network Bridge</b><br>
-						The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network bridge to the host.
+						<b>Network Source</b><br>
+						The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network to the host.
 					</p>
 
 				<p>
@@ -882,12 +887,17 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</td>
 				</tr>
 				<tr class="advanced">
-					<td>_(Network Bridge)_:</td>
+					<td>_(Network Source)_:</td>
 					<td>
 						<select name="nic[{{INDEX}}][network]">
 						<?
-						foreach ($arrValidBridges as $strBridge) {
-							echo mk_option($domain_bridge, $strBridge, $strBridge);
+						foreach (array_keys($arrValidNetworks) as $key) {
+
+							echo mk_option("", $key, "- ".$key." -", "disabled");
+
+							foreach ($arrValidNetworks as $strNetwork) {
+								echo mk_option($domain_bridge, $strNetwork, $strNetwork);
+							}
 						}
 						?>
 						</select>

--- a/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
@@ -833,7 +833,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						<?
 						foreach (array_keys($arrValidNetworks) as $key) {
 
-							echo mk_option("", $key, "- ".$key." -", "disabled");
+							echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 							foreach ($arrValidNetworks as $strNetwork) {
 								echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
@@ -893,7 +893,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						<?
 						foreach (array_keys($arrValidNetworks) as $key) {
 
-							echo mk_option("", $key, "- ".$key." -", "disabled");
+							echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 							foreach ($arrValidNetworks as $strNetwork) {
 								echo mk_option($domain_bridge, $strNetwork, $strNetwork);

--- a/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
@@ -833,7 +833,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						<?
 						foreach (array_keys($arrValidNetworks) as $key) {
 
-							echo mk_option("", $key, "- ".$key." -", "disabled");
+							echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 							foreach ($arrValidNetworks as $strNetwork) {
 								echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
@@ -893,7 +893,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						<?
 						foreach (array_keys($arrValidNetworks) as $key) {
 
-							echo mk_option("", $key, "- ".$key." -", "disabled");
+							echo mk_option("", $key, "- "._($key)." -", "disabled");
 
 							foreach ($arrValidNetworks as $strNetwork) {
 								echo mk_option($domain_bridge, $strNetwork, $strNetwork);

--- a/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
@@ -28,7 +28,7 @@
 	$arrValidOtherDevices = getValidOtherDevices();
 	$arrValidUSBDevices = getValidUSBDevices();
 	$arrValidDiskDrivers = getValidDiskDrivers();
-	$arrValidBridges = getNetworkBridges();
+	$arrValidNetworks = getValidNetworks();
 	$strCPUModel = getHostCPUModel();
 
 	// Read localpaths in from openelec.cfg
@@ -827,12 +827,17 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</td>
 				</tr>
 				<tr class="advanced">
-					<td>_(Network Bridge)_:</td>
+					<td>_(Network Source)_:</td>
 					<td>
 						<select name="nic[<?=$i?>][network]">
 						<?
-						foreach ($arrValidBridges as $strBridge) {
-							echo mk_option($arrNic['network'], $strBridge, $strBridge);
+						foreach (array_keys($arrValidNetworks) as $key) {
+
+							echo mk_option("", $key, "- ".$key." -", "disabled");
+
+							foreach ($arrValidNetworks as $strNetwork) {
+								echo mk_option($arrNic['network'], $strNetwork, $strNetwork);
+							}
 						}
 						?>
 						</select>
@@ -859,8 +864,8 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</p>
 
 					<p>
-						<b>Network Bridge</b><br>
-						The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network bridge to the host.
+						<b>Network Source</b><br>
+						The default libvirt managed network bridge (virbr0) will be used, otherwise you may specify an alternative name for a private network to the host.
 					</p>
 
 				<p>
@@ -882,12 +887,17 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 					</td>
 				</tr>
 				<tr class="advanced">
-					<td>_(Network Bridge)_:</td>
+					<td>_(Network Source)_:</td>
 					<td>
 						<select name="nic[{{INDEX}}][network]">
 						<?
-						foreach ($arrValidBridges as $strBridge) {
-							echo mk_option($domain_bridge, $strBridge, $strBridge);
+						foreach (array_keys($arrValidNetworks) as $key) {
+
+							echo mk_option("", $key, "- ".$key." -", "disabled");
+
+							foreach ($arrValidNetworks as $strNetwork) {
+								echo mk_option($domain_bridge, $strNetwork, $strNetwork);
+							}
 						}
 						?>
 						</select>


### PR DESCRIPTION
This PR gives the user the option of using LibVirt networks in addition to bridges without having to edit the VM's XML.

I tested the changes locally on my Unraid and so far have not found any errors.

Example of a tested network:
```
<network>
  <name>sriov0</name>
  <uuid>bbb1fc77-0d0e-45c9-b577-597ac9d4792c</uuid>
  <forward mode='hostdev' managed='yes'>
    <pf dev='eth3'/>
    <address type='pci' domain='0x0000' bus='0x81' slot='0x10' function='0x1'/>
    <address type='pci' domain='0x0000' bus='0x81' slot='0x10' function='0x2'/>
    <address type='pci' domain='0x0000' bus='0x81' slot='0x10' function='0x3'/>
    ...
  </forward>
</network>
```

![image](https://user-images.githubusercontent.com/48415231/137464436-69e7d36e-57b4-40fc-be29-f51f1e97ccd4.png)
![image](https://user-images.githubusercontent.com/48415231/137464457-bd1f0076-78f2-47fd-915b-41328a19013f.png)
