### PR TITLE
Allow CA to get all docker info without having to download icons if not present

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -283,7 +283,7 @@ class DockerTemplates {
 		return $WebUI;
 	}
 
-	public function getAllInfo($reload=false,$com=true) {
+	public function getAllInfo($reload=false,$com=true,$communityApplications=false) {
 		global $dockerManPaths, $host;
 		$DockerClient = new DockerClient();
 		$DockerUpdate = new DockerUpdate();
@@ -301,7 +301,9 @@ class DockerTemplates {
 			// read docker label for WebUI & Icon
 			if ($ct['Url'] && !$tmp['url']) $tmp['url'] = $ct['Url'];
 			if ($ct['Icon']) $tmp['icon'] = $ct['Icon'];
-			if (!is_file($tmp['icon']) || $reload) $tmp['icon'] = $this->getIcon($image,$name);
+			if ( ! $communityApplications ) {
+				if (!is_file($tmp['icon']) || $reload) $tmp['icon'] = $this->getIcon($image,$name);
+			}
 			if ($ct['Running']) {
 				$port = &$ct['Ports'][0];
 				$ip = ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : $port['IP']);


### PR DESCRIPTION
CA requires getAllInfo to operate properly with a new update, but in case of networking issues this slows down the system if dockerMan is unable to download the icon (and keeps trying).  CA doesn't care about the icon, so skip downloading them if the request is coming from CA