### PR TITLE
Always show "WebUI" for user specified URLs

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -305,8 +305,14 @@ class DockerTemplates {
 			}
 			if ($ct['Running']) {
 				$port = &$ct['Ports'][0];
-				$ip = ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : $port['IP']);
-				$tmp['url'] = $ip ? (strpos($tmp['url'],$ip)!==false ? $tmp['url'] : $this->getControlURL($ct, $ip)) : $tmp['url'];
+				$webui = $this->getTemplateValue($ct['Image'], 'WebUI');
+				if (strlen($webui) > 0 && !preg_match("%\[(IP|PORT:(\d+))\]%", $webui)) {
+					// non-templated webui, user specified
+					$tmp['url'] = $webui;
+				} else {
+					$ip = ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : $port['IP']);
+					$tmp['url'] = $ip ? (strpos($tmp['url'],$ip)!==false ? $tmp['url'] : $this->getControlURL($ct, $ip)) : $tmp['url'];
+				}
 				$tmp['shell'] = $tmp['shell'] ?? $this->getTemplateValue($image, 'Shell');
 			}
 			$tmp['registry'] = $tmp['registry'] ?? $this->getTemplateValue($image, 'Registry');


### PR DESCRIPTION
I often specify custom WebUI URLs based on my network/local-domain
setup. I rarely if ever use "http://[IP]:[PORT:8888]/" templated URLs.

This change maintains support for the existing templated
bridged/host-network URL schema while enabling the "WebUI" affordance
for containers where the user explicitly entered a WebUI url, e.g.
"https://grafana.mylan.io"