### PR TITLE
Change Dashboard Parity status to be invalid and not emulated.

### DIFF
--- a/plugins/dynamix/nchan/update_2
+++ b/plugins/dynamix/nchan/update_2
@@ -148,7 +148,7 @@ function device_status(&$disk, &$error, &$warning) {
     case 'green-blink' : $color = 'grey';   $text = 'standby';    break;
     case 'blue-on'     : $color = 'blue';   $text = 'unassigned'; break;
     case 'blue-blink'  : $color = 'grey';   $text = 'unassigned'; break;
-    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? 'invalid') : 'emulated';   $warning++; break;
+    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? 'invalid' : 'emulated';   $warning++; break;
     case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? 'invalid' : 'emulated';   $warning++; break;
     case 'red-on'      : $color = 'red';    $text = 'disabled';   $error++; break;
     case 'red-blink'   : $color = 'grey';   $text = 'disabled';   $error++; break;

--- a/plugins/dynamix/nchan/update_2
+++ b/plugins/dynamix/nchan/update_2
@@ -144,16 +144,16 @@ function device_status(&$disk, &$error, &$warning) {
   if ($disk['type']!='Extra' && $var['fsState']=='Stopped') {
     $color = 'green'; $text = 'off-line';
   } else switch ($disk['color']) {
-    case 'green-on'    : $color = 'green';  $text = _('active');     break;
-    case 'green-blink' : $color = 'grey';   $text = _('standby');    break;
-    case 'blue-on'     : $color = 'blue';   $text = _('unassigned'); break;
-    case 'blue-blink'  : $color = 'grey';   $text = _('unassigned'); break;
-    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? _('invalid') : _('emulated');   $warning++; break;
-    case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? _('invalid') : _('emulated');   $warning++; break;
-    case 'red-on'      : $color = 'red';    $text = _('disabled');   $error++; break;
-    case 'red-blink'   : $color = 'grey';   $text = _('disabled');   $error++; break;
-    case 'red-off'     : $color = 'red';    $text = _('faulty');     $error++; break;
-    case 'grey-off'    : $color = 'grey';   $text = _('no device');  break;
+    case 'green-on'    : $color = 'green';  $text = 'active';     break;
+    case 'green-blink' : $color = 'grey';   $text = 'standby';    break;
+    case 'blue-on'     : $color = 'blue';   $text = 'unassigned'; break;
+    case 'blue-blink'  : $color = 'grey';   $text = 'unassigned'; break;
+    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? 'invalid') : 'emulated';   $warning++; break;
+    case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? 'invalid' : 'emulated';   $warning++; break;
+    case 'red-on'      : $color = 'red';    $text = 'disabled';   $error++; break;
+    case 'red-blink'   : $color = 'grey';   $text = 'disabled';   $error++; break;
+    case 'red-off'     : $color = 'red';    $text = 'faulty';     $error++; break;
+    case 'grey-off'    : $color = 'grey';   $text = 'no device';  break;
   }
   return "<i class='fa fa-circle orb $color-orb middle'></i>"._($text);
 }

--- a/plugins/dynamix/nchan/update_2
+++ b/plugins/dynamix/nchan/update_2
@@ -148,8 +148,8 @@ function device_status(&$disk, &$error, &$warning) {
     case 'green-blink' : $color = 'grey';   $text = 'standby';    break;
     case 'blue-on'     : $color = 'blue';   $text = 'unassigned'; break;
     case 'blue-blink'  : $color = 'grey';   $text = 'unassigned'; break;
-    case 'yellow-on'   : $color = 'yellow'; $text = 'emulated';   $warning++; break;
-    case 'yellow-blink': $color = 'grey';   $text = 'emulated';   $warning++; break;
+    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? _('rebuild or invalid') : _('emulated');   $warning++; break;
+    case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? _('rebuild or invalid') : _('emulated');   $warning++; break;
     case 'red-on'      : $color = 'red';    $text = 'disabled';   $error++; break;
     case 'red-blink'   : $color = 'grey';   $text = 'disabled';   $error++; break;
     case 'red-off'     : $color = 'red';    $text = 'faulty';     $error++; break;

--- a/plugins/dynamix/nchan/update_2
+++ b/plugins/dynamix/nchan/update_2
@@ -144,16 +144,16 @@ function device_status(&$disk, &$error, &$warning) {
   if ($disk['type']!='Extra' && $var['fsState']=='Stopped') {
     $color = 'green'; $text = 'off-line';
   } else switch ($disk['color']) {
-    case 'green-on'    : $color = 'green';  $text = 'active';     break;
-    case 'green-blink' : $color = 'grey';   $text = 'standby';    break;
-    case 'blue-on'     : $color = 'blue';   $text = 'unassigned'; break;
-    case 'blue-blink'  : $color = 'grey';   $text = 'unassigned'; break;
-    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? _('rebuild or invalid') : _('emulated');   $warning++; break;
-    case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? _('rebuild or invalid') : _('emulated');   $warning++; break;
-    case 'red-on'      : $color = 'red';    $text = 'disabled';   $error++; break;
-    case 'red-blink'   : $color = 'grey';   $text = 'disabled';   $error++; break;
-    case 'red-off'     : $color = 'red';    $text = 'faulty';     $error++; break;
-    case 'grey-off'    : $color = 'grey';   $text = 'no device';  break;
+    case 'green-on'    : $color = 'green';  $text = _('active');     break;
+    case 'green-blink' : $color = 'grey';   $text = _('standby');    break;
+    case 'blue-on'     : $color = 'blue';   $text = _('unassigned'); break;
+    case 'blue-blink'  : $color = 'grey';   $text = _('unassigned'); break;
+    case 'yellow-on'   : $color = 'yellow'; $text =  $disk['type']=='Parity' ? _('invalid') : _('emulated');   $warning++; break;
+    case 'yellow-blink': $color = 'grey';   $text =  $disk['type']=='Parity' ? _('invalid') : _('emulated');   $warning++; break;
+    case 'red-on'      : $color = 'red';    $text = _('disabled');   $error++; break;
+    case 'red-blink'   : $color = 'grey';   $text = _('disabled');   $error++; break;
+    case 'red-off'     : $color = 'red';    $text = _('faulty');     $error++; break;
+    case 'grey-off'    : $color = 'grey';   $text = _('no device');  break;
   }
   return "<i class='fa fa-circle orb $color-orb middle'></i>"._($text);
 }


### PR DESCRIPTION
Please find suggested changes to Dash board view if Parity is invalid or being rebuilt, Currently it says emulated.

Let me know if I should remove multi-lang or add to others and status if you think should be something different to rebuild or invalid.

Made the same change on my 6.9.2 server as its currently rebuilding parity.

![image](https://user-images.githubusercontent.com/39065407/155496318-9da31530-4fc0-44be-9d13-c57a41f7fb67.png)
