### PR TITLE
Show IP on VM Manager VM Page

### DIFF
--- a/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -185,7 +185,7 @@ foreach ($vms as $vm) {
         $prevnamemac = $ipnamemac ;
         }
     }
-  } else echo "<tr><td>"._('Guest not running or guest agent not install')."</td><td></td><td></td><td></td></tr>";
+  } else echo "<tr><td>"._('Guest not running or guest agent not installed')."</td><td></td><td></td><td></td></tr>";
   
   echo "</tbody></table>";
   echo "</td></tr>";

--- a/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -164,6 +164,29 @@ foreach ($vms as $vm) {
     $bus = $arrValidDiskBuses[$arrCD['bus']] ?? 'VirtIO';
     echo "<tr><td>$disk</td><td>$bus</td><td>$capacity</td><td>$allocation</td></tr>";
   }
+
+  /* Display VM  IP Addresses "execute":"guest-network-get-interfaces" --pretty */
+  echo "<thead><tr><th><i class='fa fa-hdd-o'></i> <b>"._('IP Interfaces')."</b></th><th>"._('Type')."</th><th>"._('IP')."</th><th>"._('Prefix')."</th></tr></thead>";
+  $ip=$lv->domain_qemu_agent_command($res, '{"execute":"guest-network-get-interfaces"}', 10, 0) ;
+  if ($ip != false) { 
+    $ip=json_decode($ip,true) ; 
+    $ip=$ip["return"] ; 
+    foreach ($ip as $arrIP) {
+      $ipname = $arrIP["name"] ;
+      $iphdwadr = $arrIP["hardware-address"] == "" ?  _("N/A") : $arrIP["hardware-address"] ;
+      $iplist = $arrIP["ip-addresses"] ;
+      foreach ($iplist as $arraddr) {
+        $ipaddrval = $arraddr["ip-address"] ;
+        $iptype= $arraddr["ip-address-type"] ;
+        $ipprefix =$arraddr["prefix"] ;
+        $ipnamemac = "$ipname($iphdwadr)" ;
+        if ($ipnamemac == $prevnamemac) $ipnamemac = " " ;
+        echo "<tr><td>$ipnamemac</td><td>$iptype</td><td>$ipaddrval</td><td>$ipprefix</td></tr>";
+        $prevnamemac = $ipnamemac ;
+        }
+    }
+  } else echo "<tr><td>"._('Guest not running or guest agent not install')."</td><td></td><td></td><td></td></tr>";
+  
   echo "</tbody></table>";
   echo "</td></tr>";
 }

--- a/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -166,23 +166,25 @@ foreach ($vms as $vm) {
   }
 
   /* Display VM  IP Addresses "execute":"guest-network-get-interfaces" --pretty */
-  echo "<thead><tr><th><i class='fa fa-hdd-o'></i> <b>"._('IP Interfaces')."</b></th><th>"._('Type')."</th><th>"._('IP')."</th><th>"._('Prefix')."</th></tr></thead>";
+  echo "<thead><tr><th><i class='fa fa-sitemap'></i> <b>"._('IP Interfaces')."</b></th><th>"._('Type')."</th><th>"._('IP')."</th><th>"._('Prefix')."</th></tr></thead>";
   $ip=$lv->domain_qemu_agent_command($res, '{"execute":"guest-network-get-interfaces"}', 10, 0) ;
   if ($ip != false) { 
     $ip=json_decode($ip,true) ; 
     $ip=$ip["return"] ; 
+    $duplicates = []; // hide duplicate interface names
     foreach ($ip as $arrIP) {
       $ipname = $arrIP["name"] ;
+      if (preg_match('/^(lo|Loopback)/',$ipname)) continue; // omit loopback interface
       $iphdwadr = $arrIP["hardware-address"] == "" ?  _("N/A") : $arrIP["hardware-address"] ;
       $iplist = $arrIP["ip-addresses"] ;
       foreach ($iplist as $arraddr) {
         $ipaddrval = $arraddr["ip-address"] ;
+        if (preg_match('/^f[c-f]/',$ipaddrval)) continue; // omit ipv6 private addresses
         $iptype= $arraddr["ip-address-type"] ;
         $ipprefix =$arraddr["prefix"] ;
         $ipnamemac = "$ipname($iphdwadr)" ;
-        if ($ipnamemac == $prevnamemac) $ipnamemac = " " ;
+        if (!in_array($ipnamemac,$duplicates)) $duplicates[] = $ipnamemac; else $ipnamemac = "";
         echo "<tr><td>$ipnamemac</td><td>$iptype</td><td>$ipaddrval</td><td>$ipprefix</td></tr>";
-        $prevnamemac = $ipnamemac ;
         }
     }
   } else echo "<tr><td>"._('Guest not running or guest agent not installed')."</td><td></td><td></td><td></td></tr>";

--- a/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/plugins/dynamix.vm.manager/include/libvirt.php
@@ -1607,6 +1607,12 @@
 			return ($tmp) ? $tmp : $this->_set_last_error();
 		}
 
+		function domain_qemu_agent_command($domain,$cmd,$timeout,$flags) {
+			$domain = $this->get_domain_object($domain);
+			$tmp = libvirt_domain_qemu_agent_command($domain,$cmd,$timeout,$flags);
+			return ($tmp) ? $tmp : $this->_set_last_error();
+		}
+
 		function generate_uuid($seed=false) {
 			if (!$seed)
 				$seed = time();


### PR DESCRIPTION
Please find a PR for review to add IP addresses to the VM Manager page. Function is dependant on guest agent being installed on the guest.

Information is added as part of the disk information drop down.  Here is the new view on my test system. Let me know if you would like anything to be changed.


![image](https://user-images.githubusercontent.com/39065407/161425343-baeda012-01ab-401e-88f1-afdc6204c798.png)
