### PR TITLE
Docker: Ignore icon references to default question mark

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -338,7 +338,7 @@ class DockerTemplates {
 	public function getIcon($Repository,$contName) {
 		global $docroot, $dockerManPaths;
 		$imgUrl = $this->getTemplateValue($Repository, 'Icon','all',$contName);
-		if (!$imgUrl) return '';
+		if (!$imgUrl || trim($imgUrl) == "/plugins/dynamix.docker.manager/images/question.png") return '';
 
 		$imageName = $contName ?: $name;
 		$iconRAM = sprintf('%s/%s-%s.png', $dockerManPaths['images-ram'], $contName, 'icon');


### PR DESCRIPTION
re: https://forums.unraid.net/bug-reports/prereleases/610rc5-r1846/

Caused by previous versions of CA adding an Icon reference that isn't valid under rc5+