### PR TITLE
Use docker label as primary source for WebUI

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -268,11 +268,12 @@ class DockerTemplates {
 		return false;
 	}
 
-	private function getControlURL(&$ct, $myIP) {
+	private function getControlURL(&$ct, $myIP, $WebUI) {
 		global $host;
 		$port = &$ct['Ports'][0];
 		$myIP = $myIP ?: $this->getTemplateValue($ct['Image'], 'MyIP') ?: ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : ($port['IP'] ?: DockerUtil::myIP($ct['Name'])));
-		$WebUI = preg_replace("%\[IP\]%", $myIP, $this->getTemplateValue($ct['Image'], 'WebUI'));
+		// Get the WebUI address from the templates as a fallback
+		$WebUI = preg_replace("%\[IP\]%", $myIP, $WebUI ?: $this->getTemplateValue($ct['Image'], 'WebUI'));
 		if (preg_match("%\[PORT:(\d+)\]%", $WebUI, $matches)) {
 			$ConfigPort = $matches[1];
 			foreach ($ct['Ports'] as $port) {
@@ -312,7 +313,7 @@ class DockerTemplates {
 					$tmp['url'] = $webui;
 				} else {
 					$ip = ($ct['NetworkMode']=='host'||$port['NAT'] ? $host : $port['IP']);
-					$tmp['url'] = $ip ? (strpos($tmp['url'],$ip)!==false ? $tmp['url'] : $this->getControlURL($ct, $ip)) : $tmp['url'];
+					$tmp['url'] = $ip ? (strpos($tmp['url'],$ip)!==false ? $tmp['url'] : $this->getControlURL($ct, $ip, $tmp['url'])) : $tmp['url'];
 				}
 				$tmp['shell'] = $tmp['shell'] ?? $this->getTemplateValue($image, 'Shell');
 			}


### PR DESCRIPTION
In this PR, I propose the use of the docker label `net.unraid.docker.webui` as
the primary source when parsing the container's web UI address. In the case that
the label is missing (i.e. for containers that were created before upgrading to
OS 6.10.X), we will fallback to the retrieving the details from the XML template.

There are 2 reasons for proposing this PR:
1. Compatibility with `docker-compose`. The current set up only explicitly
   refers to the XML template for the web UI address. This rules out all
   Compose files that are spun up that do not reference a container that were
   once spun up before using a template. Thus, no web UI option will be provided
   for such containers.
2. Speed when loading the Docker page. The web UI address is parsed by
   retrieving the address format from the XML template in the private
   function `getControlURL`. This is called within the public function
   `getAllInfo`. However, before calling `getControlURL`, we would already have
   read through the container's labels and assigned `net.unraid.docker.webui` to
   a temporary variable. For all recently created containers with defined web UI
   addresses, this variable will be non-empty and, if spun up using a template,
   is the same as the template value obtained from the XML template. It would be
   much faster to just use the label's value instead of calling another function
   that furnishes the same value after an I/O operation.

On my server with about 60 running containers, I have measured a drop from 9.5s
to 9.0s, over an average of 10 tests, with and without applying the changes of
this PR. I only have 1 server and it is running an i7-8770. The difference would
not be as pronounced with faster CPUs but it should still be present. I believe
that this result shows some support in my claims in reason #2 above.