### PR TITLE
Update ssh key regex

### DIFF
--- a/plugins/dynamix/UserEdit.page
+++ b/plugins/dynamix/UserEdit.page
@@ -116,10 +116,8 @@ function checkKey(form) {
   // check syntax of ssh keys
   var rows = form.text.value.split('\n');
   for (var i=0,row; row=rows[i]; i++) {
-    var data = row.split(' ');
-    // key must have 3 fields, starts with ssh or ecdsa, and is for user
-    if (data.length!=3 || data[0].search(/^(ssh|ecdsa)/)==-1 || data[2].search('@')==-1) {
-      swal({title:"_(Invalid Key)_",text:"["+(i+1)+"] "+data[0].substr(0,10)+": _(Syntax of the key is incorrect)_!",type:"error",html:true,confirmButtonText:"_(Ok)_"});
+    if (row.search(/^(ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29t|ssh-rsa AAAAB3NzaC1yc2)[0-9A-Za-z+/]+[=]{0,3}(\s.*)?$/)==-1) {
+      swal({title:"_(Invalid Key)_",text:"["+(i+1)+"] "+row.split(' ')[0]+": _(Syntax of the key is incorrect)_!",type:"error",html:true,confirmButtonText:"_(Ok)_"});
       return false;
     }
   }


### PR DESCRIPTION
Add support for ed25519/sk-ed25519
Remove support for ecdsa (insecure)
Use proper regex to check for valid key types

Ref:
https://forums.unraid.net/bug-reports/stable-releases/6103-ui-field-for-root-ssh-authorized-keys-does-not-support-ed25519-and-other-valid-key-types-r2023/
https://github.com/nemchik/ssh-key-regex