### PR TITLE
Add nvme capabilities

### DIFF
--- a/plugins/dynamix/DeviceCapabilities.page
+++ b/plugins/dynamix/DeviceCapabilities.page
@@ -18,13 +18,13 @@ Cond="strpos($disks[$name]['status'],'_NP')===false"
 <script>
 $(function() {
   $.post("/webGui/include/SmartInfo.php",{cmd:'capabilities',port:'<?=addslashes(htmlspecialchars($dev))?>',name:'<?=addslashes(htmlspecialchars($name))?>'}, function(data) {
-    $('#disk_capabilities_table').html(data);
+    $('#disk_capabilities_div').html(data);
   });
 });
 </script>
-<table id="disk_capabilities_table" class='share_status small'>
+<div id="disk_capabilities_div" class='share_status small'>
 
-</table>
+</div>
 <input type="button" value="_(Done)_" onclick="done()">
 
 :smart_capabilities_help:

--- a/plugins/dynamix/DeviceCapabilities.page
+++ b/plugins/dynamix/DeviceCapabilities.page
@@ -18,13 +18,12 @@ Cond="strpos($disks[$name]['status'],'_NP')===false"
 <script>
 $(function() {
   $.post("/webGui/include/SmartInfo.php",{cmd:'capabilities',port:'<?=addslashes(htmlspecialchars($dev))?>',name:'<?=addslashes(htmlspecialchars($name))?>'}, function(data) {
-    $('#disk_capabilities').html(data);
+    $('#disk_capabilities_table').html(data);
   });
 });
 </script>
-<table class='share_status small'>
-<thead><td style="width:33%">_(Feature)_</td><td>_(Value)_</td><td>_(Information)_</td></thead>
-<tbody id="disk_capabilities"><tr><td colspan='3'><div class="spinner"></div></td></tr></tbody>
+<table id="disk_capabilities_table" class='share_status small'>
+
 </table>
 <input type="button" value="_(Done)_" onclick="done()">
 

--- a/plugins/dynamix/include/SmartInfo.php
+++ b/plugins/dynamix/include/SmartInfo.php
@@ -108,8 +108,6 @@ case "capabilities":
     if (!$line) {echo "<tr></tr>" ;continue;}
     $line = preg_replace('/^_/','__',preg_replace(['/__+/','/_ +_/'],'_',str_replace([chr(9),')','('],'_',$line)));
     $info = array_map('trim', explode('_', preg_replace('/_( +)_ /','__',$line), 3));
-    if ($nvme && $info[0]=="Supported Power States" ) { $nvme_section="psheading" ; continue ;}
-    if ($nvme && $info[0]=="Supported LBA Sizes" ) { $nvme_section="lbaheading" ; continue ;} 
     append($row[0],$info[0]);
     append($row[1],$info[1]);
     append($row[2],$info[2]);
@@ -118,14 +116,22 @@ case "capabilities":
       $row = ['','',''];
       $empty = false;
     }
+    if ($nvme && $info[0]=="Supported Power States" ) { $nvme_section="psheading" ; $row = ['','',''] ; continue ;}
+    if ($nvme && $info[0]=="Supported LBA Sizes" ) {  
+      echo "<tr><td>${row[0]}</td><td>${row[1]}</td><td>${row[2]}</td></tr>";
+      $row = ['','',''];
+      $nvme_section="lbaheading" ; 
+      continue ;
+    } 
     if ($nvme && $nvme_section == "psheading") {
-      echo '<tr><td></td><td></td><td></td></tr></body><div><thead>' ;
+      echo '</body><thead>' ;
       $nvme_section = "psdetail";
       preg_match('/^(?P<data1>.\S+)\s+(?P<data2>\S+)\s+(?P<data3>\S+)\s+(?P<data4>\S+)\s+(?P<data5>\S+)\s+(?P<data6>\S+)\s+(?P<data7>\S+)\s+(?P<data8>\S+)\s+(?P<data9>\S+)\s+(?P<data10>\S+)\s+(?P<data11>\S+)$/',$line, $psheadings);
       for ($i = 1; $i <= 11; $i++) {   
       echo "<td>".$psheadings['data'.$i]."</td>" ;
       }
-      echo '</thead><tbody><tr><td>Supported Power States</td></tr>' ;
+      $row = ['','',''];
+      echo '</thead><tbody>' ;
     }
     if ($nvme && $nvme_section == "psdetail") {
       $nvme_section = "psdetail";
@@ -134,15 +140,17 @@ case "capabilities":
       for ($i = 1; $i <= 11; $i++) {   
       echo "<td>".$psdetails['data'.$i]."</td>" ;
       }
+      $row = ['','',''];
       echo '</tr>' ;
     }
     if ($nvme && $nvme_section == "lbaheading") {
-      echo '<tr><td></td><td></td><td></td></tr></body><div><thead>' ;
+      echo '</body><thead>' ;
       $nvme_section = "lbadetail";
       preg_match('/^(?P<data1>.\S+)\s+(?P<data2>\S+)\s+(?P<data3>\S+)\s+(?P<data4>\S+)\s+(?P<data5>\S+)$/',$line, $lbaheadings);
       for ($i = 1; $i <= 5; $i++) {   
         echo "<td>".$lbaheadings['data'.$i]."</td>" ;
         }
+        $row = ['','',''];
       echo '</thead><tbody>' ;
     }
     if ($nvme && $nvme_section == "lbadetail") {
@@ -152,6 +160,7 @@ case "capabilities":
       for ($i = 1; $i <= 5; $i++) {   
         echo "<td>".$lbadetails['data'.$i]."</td>" ;
         }
+        $row = ['','',''];
       echo '</tr>' ;
     }
   }


### PR DESCRIPTION
Please find PR for adding NVME capabilities to the Disk Capabilities page.

I have only one NVME so have not been able to do extensive testing.

This is the view for a NVME drive.
![image](https://user-images.githubusercontent.com/39065407/181934016-43cf5a18-4ffe-410d-b87a-cb87755f6c58.png)

Existing view for SATA

![image](https://user-images.githubusercontent.com/39065407/181934059-d1dba6d5-093c-41f9-b03b-005bc0abaabd.png)

Smartctl output.
`root@computenode:/usr/src# smartctl -n standby -c  /dev/nvme0 
smartctl 7.3 2022-02-28 r5338 [x86_64-linux-5.18.14-Unraid] (local build)
Copyright (C) 2002-22, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Firmware Updates (0x12):            1 Slot, no Reset required
Optional Admin Commands (0x0017):   Security Format Frmw_DL Self_Test
Optional NVM Commands (0x005e):     Wr_Unc DS_Mngmt Wr_Zero Sav/Sel_Feat Timestmp
Log Page Attributes (0x0e):         Cmd_Eff_Lg Ext_Get_Lg Telmtry_Lg
Maximum Data Transfer Size:         64 Pages
Warning  Comp. Temp. Threshold:     70 Celsius
Critical Comp. Temp. Threshold:     85 Celsius

Supported Power States
St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat
 0 +     3.50W       -        -    0  0  0  0        0       0
 1 +     1.90W       -        -    1  1  1  1        0       0
 2 +     1.50W       -        -    2  2  2  2        0       0
 3 -   0.0700W       -        -    3  3  3  3     5000    1900
 4 -   0.0020W       -        -    4  4  4  4    13000  100000

Supported LBA Sizes (NSID 0x1)
Id Fmt  Data  Metadt  Rel_Perf
 0 +     512       0         1
 1 -    4096       0         0
`
