### PR TITLE
Dockerman add ability to specify shell with container label.

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerClient.php
+++ b/plugins/dynamix.docker.manager/include/DockerClient.php
@@ -302,6 +302,7 @@ class DockerTemplates {
 			// read docker label for WebUI & Icon
 			if ($ct['Url'] && !$tmp['url']) $tmp['url'] = $ct['Url'];
 			if ($ct['Icon']) $tmp['icon'] = $ct['Icon'];
+			if ($ct['Shell']) $tmp['shell'] = $ct['Shell'];
 			if ( ! $communityApplications ) {
 				if (!is_file($tmp['icon']) || $reload) $tmp['icon'] = $this->getIcon($image,$name,$tmp['icon']);
 			}
@@ -913,6 +914,7 @@ class DockerClient {
 			$c['BaseImage']   = $ct['Labels']['BASEIMAGE'] ?? false;
 			$c['Icon']        = $info['Config']['Labels']['net.unraid.docker.icon'] ?? false;
 			$c['Url']         = $info['Config']['Labels']['net.unraid.docker.webui'] ?? false;
+			$c['Shell']         = $info['Config']['Labels']['net.unraid.docker.shell'] ?? false;
 			$c['Ports']       = [];
 			if ($id) $c['NetworkMode'] = $net.str_replace('/',':',DockerUtil::ctMap($id)?:'/???');
 			if ($driver[$c['NetworkMode']]=='bridge') {


### PR DESCRIPTION
Add a new dockerman system label net.unraid.docker.shell to allow specifying what shell to use for the console link via labels.
Nominal values would be 'sh' or 'bash'.
This will allow containers not created by dockerman to still specify a shell for the webui