### PR TITLE
Add Missing USB support

### DIFF
--- a/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/plugins/dynamix.vm.manager/include/libvirt.php
@@ -262,6 +262,7 @@
 			$nics = $config['nic'];
 			$disks = $config['disk'];
 			$usb = $config['usb'];
+			$usbopt = $config['usbopt'];
 			$shares = $config['shares'];
 			$gpus = $config['gpu'];
 			$pcis = $config['pci'];
@@ -447,8 +448,12 @@
 			if (!empty($usb)) {
 				foreach($usb as $i => $v){
 					$usbx = explode(':', $v);
+					$startupPolicy = '' ;
+					if (isset($usbopt[$i])) {
+						 if (strpos($usbopt[$i], "#remove") == false) $startupPolicy = 'startupPolicy="optional"' ; 	else  $startupPolicy = '' ;
+					}	 
 					$usbstr .= "<hostdev mode='subsystem' type='usb'>
-									<source>
+									<source $startupPolicy>
 										<vendor id='0x".$usbx[0]."'/>
 										<product id='0x".$usbx[1]."'/>
 									</source>

--- a/plugins/dynamix.vm.manager/include/libvirt_helpers.php
+++ b/plugins/dynamix.vm.manager/include/libvirt_helpers.php
@@ -1179,4 +1179,45 @@
 		// set namespace
 		$new['metadata']['vmtemplate']['@attributes']['xmlns'] = 'unraid';
 	}
+
+	function getVMUSBs($strXML){
+		$arrValidUSBDevices = getValidUSBDevices() ;
+		foreach($arrValidUSBDevices as $key => $data) {
+
+			$array[$key] = [
+					'id' => $data['id'],
+					'name' => $data["name"],
+					'checked' => '',
+					'startupPolicy' => ''
+					];
+		}
+		if ($strXML !="") { 
+			$VMxml = new SimpleXMLElement($strXML);
+			$VMUSB=$VMxml->xpath('//devices/hostdev[@type="usb"]/source') ;
+			foreach($VMUSB as $USB){
+				$vendor=$USB->vendor->attributes()->id ;
+				$product=$USB->product->attributes()->id ;
+				$startupPolicy=$USB->attributes()->startupPolicy ;
+				$id = str_replace('0x', '', $vendor . ':' . $product) ;
+				$found = false ;
+				foreach($arrValidUSBDevices as $key => $data) {
+					if ($data['id'] == $id) {
+						$array[$key]['checked'] = "checked" ;
+						$array[$key]['startupPolicy'] = $startupPolicy ;
+						$found = true ;
+						break ;
+					}
+				}
+				if (!$found) {
+						$array[] = [
+						'id' => $id,
+						'name' => _("USB device is missing"),
+						'checked' => 'checked',
+						'startupPolicy' => $startupPolicy
+						];
+				}
+			}
+		}	
+		return $array ;
+	} 
 ?>

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -1114,6 +1114,8 @@
 	</script>
 
 	<table>
+		<tr><td></td>
+		<td>_(Select)_&nbsp&nbsp_(Optional)_</td></tr></div> 
 		<tr>
 			<td>_(USB Devices)_:</td>
 			<td>
@@ -1122,7 +1124,8 @@
 					if (!empty($arrVMUSBs)) {
 						foreach($arrVMUSBs as $i => $arrDev) {
 						?>
-						<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
+						<label for="usb<?=$i?>">&nbsp&nbsp&nbsp&nbsp<input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>
+						/> &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <input type="checkbox" name="usbopt[]" id="usbopt<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if ($arrDev["startupPolicy"] =="optional") echo 'checked="checked"';?>/>&nbsp&nbsp&nbsp <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
 						<?
 						}
 					} else {
@@ -1506,7 +1509,7 @@ $(function() {
 
 		<?if (!$boolNew):?>
 		// signal devices to be added or removed
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="pci[]"],input[name="usbopt[]"]').each(function(){
 			if (!$(this).prop('checked')) $(this).prop('checked',true).val($(this).val()+'#remove');
 		});
 		// remove unused graphic cards
@@ -1533,7 +1536,7 @@ $(function() {
 		var postdata = form.find('input,select').serialize().replace(/'/g,"%27");
 		<?if (!$boolNew):?>
 		// keep checkbox visually unchecked
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="usbopt[]"],input[name="pci[]"]').each(function(){
 			if ($(this).val().indexOf('#remove')>0) $(this).prop('checked',false);
 		});
 		<?endif?>

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -1138,6 +1138,7 @@
 	</table>
 	<blockquote class="inline_help">
 		<p>If you wish to assign any USB devices to your guest, you can select them from this list.</p>
+		<p>Select optional if you want device to be ignored when VM starts if not present.</p>
 	</blockquote>
 
 	<table>

--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -244,12 +244,14 @@
 		$strXML = $lv->domain_get_xml($dom);
 		$boolNew = false;
 		$arrConfig = array_replace_recursive($arrConfigDefaults, domain_to_config($uuid));
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	} else {
 		// edit new VM
 		$boolRunning = false;
 		$strXML = '';
 		$boolNew = true;
 		$arrConfig = $arrConfigDefaults;
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	}
 	// Add any custom metadata field defaults (e.g. os)
 	if (!$arrConfig['template']['os']) {
@@ -1115,10 +1117,10 @@
 		<tr>
 			<td>_(USB Devices)_:</td>
 			<td>
-				<div class="textarea" style="width: 540px">
+				<div class="textarea" style="width: 640px">
 				<?
-					if (!empty($arrValidUSBDevices)) {
-						foreach($arrValidUSBDevices as $i => $arrDev) {
+					if (!empty($arrVMUSBs)) {
+						foreach($arrVMUSBs as $i => $arrDev) {
 						?>
 						<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
 						<?
@@ -1139,7 +1141,7 @@
 		<tr>
 			<td>_(Other PCI Devices)_:</td>
 			<td>
-				<div class="textarea" style="width: 540px">
+				<div class="textarea" style="width: 640px">
 				<?
 					$intAvailableOtherPCIDevices = 0;
 

--- a/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
@@ -922,6 +922,9 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		</script>
 
 		<table>
+			<tr><td></td>
+			<td>_(Select)_&nbsp&nbsp_(Optional)_</td></tr></div> 
+			<tr>
 			<tr>
 				<td>_(USB Devices)_:</td>
 				<td>
@@ -930,7 +933,8 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						if (!empty($arrVMUSBs)) {
 							foreach($arrVMUSBs as $i => $arrDev) {
 							?>
-							<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
+							<label for="usb<?=$i?>">&nbsp&nbsp&nbsp&nbsp<input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>
+							/> &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <input type="checkbox" name="usbopt[]" id="usbopt<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if ($arrDev["startupPolicy"] =="optional") echo 'checked="checked"';?>/>&nbsp&nbsp&nbsp <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
 							<?
 							}
 						} else {
@@ -943,6 +947,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		</table>
 		<blockquote class="inline_help">
 			<p>If you wish to assign any USB devices to your guest, you can select them from this list.</p>
+			<p>Select optional if you want device to be ignored when VM starts if not present.</p>
 		</blockquote>
 
 		<table>
@@ -1163,7 +1168,7 @@ $(function() {
 
 		<?if (!$boolNew):?>
 		// signal devices to be added or removed
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="pci[]"],input[name="usbopt[]"]').each(function(){
 			if (!$(this).prop('checked')) $(this).prop('checked',true).val($(this).val()+'#remove');
 		});
 		// remove unused graphic cards
@@ -1190,7 +1195,7 @@ $(function() {
 		var postdata = form.find('input,select').serialize().replace(/'/g,"%27");
 		<?if (!$boolNew):?>
 		// keep checkbox visually unchecked
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="pci[]"],input[name="usbopt[]"]').each(function(){
 			if ($(this).val().indexOf('#remove')>0) $(this).prop('checked',false);
 		});
 		<?endif?>

--- a/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
@@ -398,12 +398,14 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		$strXML = $lv->domain_get_xml($dom);
 		$boolNew = false;
 		$arrConfig = array_replace_recursive($arrConfigDefaults, domain_to_config($uuid));
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	} else {
 		// edit new VM
 		$boolRunning = false;
 		$strXML = '';
 		$boolNew = true;
 		$arrConfig = $arrConfigDefaults;
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	}
 
 	if (array_key_exists($arrConfig['template']['libreelec'], $arrLibreELECVersions)) {
@@ -923,10 +925,10 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			<tr>
 				<td>_(USB Devices)_:</td>
 				<td>
-					<div class="textarea" style="width:540px">
+					<div class="textarea" style="width:640px">
 					<?
-						if (!empty($arrValidUSBDevices)) {
-							foreach($arrValidUSBDevices as $i => $arrDev) {
+						if (!empty($arrVMUSBs)) {
+							foreach($arrVMUSBs as $i => $arrDev) {
 							?>
 							<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
 							<?
@@ -947,7 +949,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			<tr>
 				<td>_(Other PCI Devices)_:</td>
 				<td>
-					<div class="textarea" style="width:540px">
+					<div class="textarea" style="width:640px">
 					<?
 						$intAvailableOtherPCIDevices = 0;
 

--- a/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
@@ -398,12 +398,14 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		$strXML = $lv->domain_get_xml($dom);
 		$boolNew = false;
 		$arrConfig = array_replace_recursive($arrConfigDefaults, domain_to_config($uuid));
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	} else {
 		// edit new VM
 		$boolRunning = false;
 		$strXML = '';
 		$boolNew = true;
 		$arrConfig = $arrConfigDefaults;
+		$arrVMUSBs = getVMUSBs($strXML) ;
 	}
 
 	if (array_key_exists($arrConfig['template']['openelec'], $arrLibreELECVersions)) {
@@ -923,10 +925,10 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			<tr>
 				<td>_(USB Devices)_:</td>
 				<td>
-					<div class="textarea" style="width:540px">
+					<div class="textarea" style="width:640px">
 					<?
-						if (!empty($arrValidUSBDevices)) {
-							foreach($arrValidUSBDevices as $i => $arrDev) {
+						if (!empty($arrVMUSBs)) {
+							foreach($arrVMUSBs as $i => $arrDev) {
 							?>
 							<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
 							<?
@@ -947,7 +949,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			<tr>
 				<td>_(Other PCI Devices)_:</td>
 				<td>
-					<div class="textarea" style="width:540px">
+					<div class="textarea" style="width:640px">
 					<?
 						$intAvailableOtherPCIDevices = 0;
 

--- a/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
@@ -922,6 +922,9 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		</script>
 
 		<table>
+		<tr><td></td>
+			<td>_(Select)_&nbsp&nbsp_(Optional)_</td></tr></div> 
+			<tr>
 			<tr>
 				<td>_(USB Devices)_:</td>
 				<td>
@@ -930,7 +933,8 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 						if (!empty($arrVMUSBs)) {
 							foreach($arrVMUSBs as $i => $arrDev) {
 							?>
-							<label for="usb<?=$i?>"><input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>/> <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>
+							<label for="usb<?=$i?>">&nbsp&nbsp&nbsp&nbsp<input type="checkbox" name="usb[]" id="usb<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if (count(array_filter($arrConfig['usb'], function($arr) use ($arrDev) { return ($arr['id'] == $arrDev['id']); }))) echo 'checked="checked"';?>
+							/> &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <input type="checkbox" name="usbopt[]" id="usbopt<?=$i?>" value="<?=htmlspecialchars($arrDev['id'])?>" <?if ($arrDev["startupPolicy"] =="optional") echo 'checked="checked"';?>/>&nbsp&nbsp&nbsp <?=htmlspecialchars($arrDev['name'])?> (<?=htmlspecialchars($arrDev['id'])?>)</label><br/>							
 							<?
 							}
 						} else {
@@ -943,6 +947,7 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 		</table>
 		<blockquote class="inline_help">
 			<p>If you wish to assign any USB devices to your guest, you can select them from this list.</p>
+			<p>Select optional if you want device to be ignored when VM starts if not present.</p>
 		</blockquote>
 
 		<table>
@@ -1163,7 +1168,7 @@ $(function() {
 
 		<?if (!$boolNew):?>
 		// signal devices to be added or removed
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="pci[]"],input[name="usbopt[]"]').each(function(){
 			if (!$(this).prop('checked')) $(this).prop('checked',true).val($(this).val()+'#remove');
 		});
 		// remove unused graphic cards
@@ -1190,7 +1195,7 @@ $(function() {
 		var postdata = form.find('input,select').serialize().replace(/'/g,"%27");
 		<?if (!$boolNew):?>
 		// keep checkbox visually unchecked
-		form.find('input[name="usb[]"],input[name="pci[]"]').each(function(){
+		form.find('input[name="usb[]"],input[name="pci[]"],input[name="usbopt[]"]').each(function(){
 			if ($(this).val().indexOf('#remove')>0) $(this).prop('checked',false);
 		});
 		<?endif?>


### PR DESCRIPTION
Add Missing USB devices on list so can be removed from VM. 
Add startupPolicy fields to USB list for future updates.

These are the options available to startupPolicy 
![image](https://user-images.githubusercontent.com/39065407/190889389-94989089-e10c-46fa-865b-16d75f620b91.png)

For the GUI input it can be a select drop down for each of the values.

![image](https://user-images.githubusercontent.com/39065407/190889447-5ee978ec-62d2-4f4b-ae6a-8319598a6cd1.png)

or as per the feature request just add a check box for the optional option which I think will be the better option as the requisite option is unlikely to be used.

![image](https://user-images.githubusercontent.com/39065407/191062235-3f1c1388-6a76-4cd8-b890-a4cbd1cdd24d.png)
![image](https://user-images.githubusercontent.com/39065407/190889524-44a124ce-ac65-4e5f-afcb-ef1b5b5dee38.png)

Link to feature request:

https://forums.unraid.net/topic/127949-support-for-adding-optional-usb-devices-in-vm-manager-form-view/#comment-1165862

Used checkbox option in PR.