### PR TITLE
Fix post hook failing when plugin download fails; default scheduled parity check to non correcting.

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -585,6 +585,8 @@ if ($method == 'install') {
     if (!download($pluginURL, $plugin_file, $error)) {
       write("plugin: $error\n");
       @unlink($plugin_file);
+      // run hook scripts for post processing
+      post_hooks($error);
       done(1);
     }
   } else {

--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -577,6 +577,8 @@ if ($method == 'install') {
   $argv[2] = preg_replace('#[\x00-\x1F\x80-\xFF]#', '', $argv[2]);
   $plugin = basename($argv[2]);
   write("plugin: installing: $plugin\n");
+  // run hook scripts for pre processing
+  pre_hooks();
   // check for URL
   if (preg_match('#^https?://#',$argv[2])) {
     $pluginURL = $argv[2];

--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -232,6 +232,7 @@ function post_hooks($error='') {
 //
 function download($url, $name, &$error, $write=true) {
   $plg = basename($url);
+  $plg = str_replace('"', '', $plg);
   if ($file = popen("wget --compression=auto --no-cache --progress=dot --retry-connrefused --timeout=30 --tries=5 --waitretry=5 -O $name $url 2>&1", 'r')) {
     if ($write) write("plugin: downloading: $plg ...\r");
     $level = -1;
@@ -245,7 +246,7 @@ function download($url, $name, &$error, $write=true) {
       }
     }
     if (($perror = pclose($file)) != 0) {
-      $error = "$plg download failure (".error_desc($perror).")";
+      $error = "$plg download failure: ".error_desc($perror);
       return false;
     } elseif (filesize($name) == 0) {
       if ($write) write("plugin: download failure: zero-length file\n");

--- a/plugins/dynamix/ParityCheck.page
+++ b/plugins/dynamix/ParityCheck.page
@@ -191,8 +191,8 @@ _(Month of the year)_:
 
 _(Write corrections to parity disk)_:
 : <select name="write">
-  <?=mk_option($parity['write'], "", _("Yes"))?>
-  <?=mk_option($parity['write'], "NOCORRECT", _("No"))?>
+  <?=mk_option($parity['write'], "", _("No"))?>
+  <?=mk_option($parity['write'], "CORRECT", _("Yes"))?>
   </select>
 
 :parity_write_corrections_help:

--- a/plugins/dynamix/include/update.parity.php
+++ b/plugins/dynamix/include/update.parity.php
@@ -30,7 +30,7 @@ if (isset($_POST['#apply'])) {
     $month = $_POST['month'] ?? '*';
     $day   = $_POST['day'] ?? '*';
     $write = $_POST['write'] ?? '';
-	$write = ($write == "CORRECT") ? "" : "NOCORRECT";
+    $write = ($write == "CORRECT") ? "" : "NOCORRECT";
     $term  = $test = $end1 = $end2 = '';
     switch ($dotm) {
       case '28-31':

--- a/plugins/dynamix/include/update.parity.php
+++ b/plugins/dynamix/include/update.parity.php
@@ -30,6 +30,7 @@ if (isset($_POST['#apply'])) {
     $month = $_POST['month'] ?? '*';
     $day   = $_POST['day'] ?? '*';
     $write = $_POST['write'] ?? '';
+	$write = ($write == "CORRECT") ? "" : "NOCORRECT";
     $term  = $test = $end1 = $end2 = '';
     switch ($dotm) {
       case '28-31':


### PR DESCRIPTION
Fix post hook failure when plugin download fails.  Php reserved characters were being passed in the $error string to the post_plugin_check causing it to fail.