### PR TITLE
Change to be sure legacy 'write' setting in dynamix.cfg  is respected.

### DIFF
--- a/plugins/dynamix/ParityCheck.page
+++ b/plugins/dynamix/ParityCheck.page
@@ -34,6 +34,11 @@ if (file_exists($memory)) {
 }
 if ($parity['mode']<2) $parity['cumulative'] = '';
 if ($parity['mode']==2) $parity['frequency'] = '1';
+
+/* Change write setting for backwards compatibility. */
+if ($parity['write'] == "NOCORRECT") {
+  $parity['write'] = "no";
+}
 ?>
 <script>
 <?if ($parity['mode']==5):?>
@@ -191,8 +196,8 @@ _(Month of the year)_:
 
 _(Write corrections to parity disk)_:
 : <select name="write">
-  <?=mk_option($parity['write'], "", _("No"))?>
-  <?=mk_option($parity['write'], "CORRECT", _("Yes"))?>
+  <?=mk_option($parity['write'], "no", _("No"))?>
+  <?=mk_option($parity['write'], "yes", _("Yes"))?>
   </select>
 
 :parity_write_corrections_help:

--- a/plugins/dynamix/include/update.parity.php
+++ b/plugins/dynamix/include/update.parity.php
@@ -30,7 +30,7 @@ if (isset($_POST['#apply'])) {
     $month = $_POST['month'] ?? '*';
     $day   = $_POST['day'] ?? '*';
     $write = $_POST['write'] ?? '';
-    $write = ($write == "CORRECT") ? "" : "NOCORRECT";
+    $write = ($write == "yes") ? "" : "NOCORRECT";
     $term  = $test = $end1 = $end2 = '';
     switch ($dotm) {
       case '28-31':


### PR DESCRIPTION
The legacy setting for 'write' was 'NOCORRECT' for non-correcting parity check.  The new logic uses 'yes' and 'no' for the setting.  'NOCORRECT' is now made into a 'no' to respect the legacy setting.