### PR TITLE
Redo my failed attempt at defaulting to non-correcting parity check.

### DIFF
--- a/plugins/dynamix/ParityCheck.page
+++ b/plugins/dynamix/ParityCheck.page
@@ -34,11 +34,6 @@ if (file_exists($memory)) {
 }
 if ($parity['mode']<2) $parity['cumulative'] = '';
 if ($parity['mode']==2) $parity['frequency'] = '1';
-
-/* Change write setting for backwards compatibility. */
-if ($parity['write'] == "NOCORRECT") {
-  $parity['write'] = "no";
-}
 ?>
 <script>
 <?if ($parity['mode']==5):?>
@@ -196,8 +191,8 @@ _(Month of the year)_:
 
 _(Write corrections to parity disk)_:
 : <select name="write">
-  <?=mk_option($parity['write'], "no", _("No"))?>
-  <?=mk_option($parity['write'], "yes", _("Yes"))?>
+  <?=mk_option($parity['write'], "NOCORRECT", _("No"))?>
+  <?=mk_option($parity['write'], "", _("Yes"))?>
   </select>
 
 :parity_write_corrections_help:

--- a/plugins/dynamix/default.cfg
+++ b/plugins/dynamix/default.cfg
@@ -36,7 +36,7 @@ dotm="1"
 month="1"
 day="0"
 cron=""
-write=""
+write="NOCORRECT"
 [notify]
 display="0"
 date="d-m-Y"


### PR DESCRIPTION
My original attempt to fix the default parity check was pretty much a disaster.  This cleans that up.  All I had to do was set the write="NOCORRECT" in the default.cfg file and set the non-correcting as the first selection.  Duh!!