### PR TITLE
Fix default problem in Docker Settings where it defaults incorrectly and macvlan cannot be selected.

### DIFF
--- a/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/plugins/dynamix.docker.manager/DockerSettings.page
@@ -245,8 +245,8 @@ _(Template Authoring Mode)_:
 
 _(Docker custom network type)_:
 : <select name="DOCKER_NETWORK_TYPE">
-  <?=mk_option($dockercfg['DOCKER_NETWORK_TYPE'], '', _('macvlan'))?>
   <?=mk_option($dockercfg['DOCKER_NETWORK_TYPE'], '1', _('ipvlan'))?>
+  <?=mk_option($dockercfg['DOCKER_NETWORK_TYPE'], '0', _('macvlan'))?>
   </select>&nbsp;_(Please read the Help carefully)_.  _(Misconfiguration can cause problems)_.
 
 :docker_custom_network_type_help:
@@ -450,7 +450,7 @@ _(Docker LOG rotation)_:
 :docker_log_rotation_active_help:
 
 _(Docker custom network type)_:
-: <?=$dockercfg['DOCKER_NETWORK_TYPE']=='' ? _('macvlan') : _('ipvlan')?>
+: <?=$dockercfg['DOCKER_NETWORK_TYPE']=='0' ? _('macvlan') : _('ipvlan')?>
 
 :docker_custom_network_type_help:
 


### PR DESCRIPTION
Tom, there is a change that also needs to be made in rc.docker:
Change this:
if [[ -z $DOCKER_NETWORK_TYPE ]]; then

at line 71 to this:
if [ "$DOCKER_NETWORK_TYPE" = "0" ]; then

I don't think I have access to the rc.docker code.

Unfortunately, we should really issue an rc so we can check it internally before release.  It is causing support problems as is stands.