### PR TITLE
Update CreateDocker.php

### DIFF
--- a/plugins/dynamix.docker.manager/include/CreateDocker.php
+++ b/plugins/dynamix.docker.manager/include/CreateDocker.php
@@ -827,7 +827,7 @@ _(Read Me First)_:
 
 </div>
 <div markdown="1" class="advanced">
-_(Docker Hub URL)_:
+_(Registry URL)_:
 : <input type="text" name="contRegistry"></td>
 
 :docker_client_hub_url_help:


### PR DESCRIPTION
- changed `Docker Hub URL` to `Registry URL` because of GHCR and other new container registries becoming more and more popular.