### PR TITLE
Fix for missing NIC option

### DIFF
--- a/plugins/dynamix.vm.manager/templates/Custom.form.php
+++ b/plugins/dynamix.vm.manager/templates/Custom.form.php
@@ -1177,7 +1177,15 @@
 		</table>
 	</script>
 
-	<?foreach ($arrConfig['nic'] as $i => $arrNic) {
+	<?	if ( $arrConfig['nic'] == false) {
+	  		$arrConfig['nic']['0'] = 
+			[
+				'network' => $domain_bridge,
+				'mac' => "",
+				'model' => 'virtio-net'
+			] ;
+		}	
+	  	foreach ($arrConfig['nic'] as $i => $arrNic) {
 		$strLabel = ($i > 0) ? appendOrdinalSuffix($i + 1) : '';
 
 		?>

--- a/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/LibreELEC.form.php
@@ -898,8 +898,17 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			</table>
 		</script>
 
-		<?foreach ($arrConfig['nic'] as $i => $arrNic) {
-			$strLabel = ($i > 0) ? appendOrdinalSuffix($i + 1) : '';
+		<?	
+		if ( $arrConfig['nic'] == false) {
+			$arrConfig['nic']['0'] = 
+		  	[
+			  'network' => $domain_bridge,
+			  'mac' => "",
+			  'model' => 'virtio-net'
+		  	] ;
+	  	}	
+	  	foreach ($arrConfig['nic'] as $i => $arrNic) {
+		$strLabel = ($i > 0) ? appendOrdinalSuffix($i + 1) : '';
 
 			?>
 			<table data-category="Network" data-multiple="true" data-minimum="1" data-index="<?=$i?>" data-prefix="<?=$strLabel?>">

--- a/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
+++ b/plugins/dynamix.vm.manager/templates/OpenELEC.form.php
@@ -892,8 +892,16 @@ $hdrXML = "<?xml version='1.0' encoding='UTF-8'?>\n"; // XML encoding declaratio
 			</table>
 		</script>
 
-		<?foreach ($arrConfig['nic'] as $i => $arrNic) {
-			$strLabel = ($i > 0) ? appendOrdinalSuffix($i + 1) : '';
+		<?if ( $arrConfig['nic'] == false) {
+	  		$arrConfig['nic']['0'] = 
+			[
+				'network' => $domain_bridge,
+				'mac' => "",
+				'model' => 'virtio-net'
+			] ;
+		}
+		foreach ($arrConfig['nic'] as $i => $arrNic) {
+		$strLabel = ($i > 0) ? appendOrdinalSuffix($i + 1) : '';
 
 			?>
 			<table data-category="Network" data-multiple="true" data-minimum="1" data-index="<?=$i?>" data-prefix="<?=$strLabel?>">


### PR DESCRIPTION
If mac address is blanked on template it will remove NIC. But you cannot add back in from the template only via XML editior. This PR allows new MAC to be created to add back the NIC.