### PR TITLE
DockerSettings.page Check if docker.sock exists to determine if docker is running

### DIFF
--- a/plugins/dynamix.docker.manager/DockerSettings.page
+++ b/plugins/dynamix.docker.manager/DockerSettings.page
@@ -21,7 +21,7 @@ Tag="icon-docker"
 require_once "$docroot/plugins/dynamix.docker.manager/include/DockerClient.php";
 
 $DockerClient  = new DockerClient();
-$DockerStopped = pgrep('dockerd')===false;
+$DockerStopped = file_exists("/var/run/docker.sock")===false;
 
 function strposX($s, $c, $n=1) {
   $p = 0;


### PR DESCRIPTION
Searching for a running process named "dockerd" finds other running Docker daemons on the system, for example, in a lxc container. To check if the unraid Docker daemon is running, check if the /var/run/docker.sock file was created.