### PR TITLE
Fix table layout for orphan images

### DIFF
--- a/plugins/dynamix.docker.manager/include/DockerContainers.php
+++ b/plugins/dynamix.docker.manager/include/DockerContainers.php
@@ -152,7 +152,7 @@ foreach ($images as $image) {
   $menu = sprintf("onclick=\"addDockerImageContext('%s','%s')\"", $id, implode(',',$image['Tags']));
   echo "<tr class='advanced'><td style='width:220px;padding:8px'>";
   echo "<span class='outer apps'><span id='$id' $menu class='hand'><img src='/webGui/images/disk.png' class='img'></span><span class='inner'>("._('orphan image').")<br><i class='fa fa-square stopped grey-text'></i><span class='state'>"._('stopped')."</span></span></span>";
-  echo "</td><td colspan='5'>"._('Image ID').": $id<br>";
+  echo "</td><td colspan='6'>"._('Image ID').": $id<br>";
   echo implode(', ',$image['Tags']);
   echo "</td><td>"._('Created')." ".htmlspecialchars(_($image['Created'],0))."</td></tr>";
 }


### PR DESCRIPTION
The orphan image current span results in `Created xx ago` is not aligned with the right column:

Old:
![grafik](https://user-images.githubusercontent.com/87267/227734462-3a719b35-d6b2-4f47-bcf7-5ffa0f71eb54.png)


New:
![grafik](https://user-images.githubusercontent.com/87267/227734451-07e31d77-e467-4093-a36d-b3b05e0696f6.png)
