### PR TITLE
Make wget percentage detection more robust

### DIFF
--- a/plugins/dynamix.plugin.manager/scripts/plugin
+++ b/plugins/dynamix.plugin.manager/scripts/plugin
@@ -238,9 +238,9 @@ function download($url, $name, &$error, $write=true) {
     if ($file = popen("wget --compression=auto --no-cache --progress=dot --retry-connrefused --prefer-family=IPv4 --timeout=10 --tries=$tries --waitretry=$tries -O $name $url 2>&1", 'r')) {
       if ($write) write("plugin: downloading: $plg ...\r");
       $level = -1;
-      while (($line = fgets($file)) !== false) {
-        if (preg_match('/\d+%/', $line, $matches)) {
-          $percentage = substr($matches[0],0,-1);
+        while (($line = fgets($file)) !== false) {
+            if (preg_match('/ \d+% /', $line, $matches)) {
+                $percentage = substr(trim($matches[0]),0,-1);
           if ($percentage > $level) {
             if ($write) write("plugin: downloading: $plg ... $percentage%\r");
             $level = $percentage;


### PR DESCRIPTION
Sometimes I see percentages like `20230330%` on the plugin install screen during download. And i wondered why...

I saved the example wget output and tested the [regex](https://github.com/limetech/webgui/blob/8a0546ad7c78821083d6aec3a6a15ada13ebade7/plugins/dynamix.plugin.manager/scripts/plugin#L242) against it. Turns out, that the output contains:

```
Credential=AKIAIWNJYAX4CSVEH53A%2F20230330%2Fus-east-1%2Fs3%2Faws4_request
```

You see the percentage sign? It matches!

So I took a look to the wget out with the right percentage (`0K .......... .......... 100% 7.88M=0.003s`). before and after are always whitespaces, so I changed the regex accordingly: https://regex101.com/r/RhlZji/1

Thats worked.

I put it all together with a final trim to remove the whitespaces before dealing with it further.