### PR TITLE
VM Manager Updates

### DIFF
--- a/languages/en_US/helptext.txt
+++ b/languages/en_US/helptext.txt
@@ -1602,6 +1602,11 @@ When shutting down the server, this defines how long to wait in seconds for *gra
 NOTE: It's recommended to shut down guest VMs from within the VM.
 :end
 
+:vms_console_help:
+For setting the console options to show on context menus. Web will show only inbuild web clients(VNC and SPICE), 
+Virtual Manager Remote Viewer will only show the Remote Viewer option. Both will show both Web and Remote Viewer.
+:end
+
 :vms_acs_override_help:
 *PCIe ACS override* allows various hardware components to expose themselves as isolated devices.
 Typically it is sufficient to isolate *Downstream* ports.

--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -188,8 +188,8 @@ _(VM shutdown time-out)_:
 _(Console Options)_:
 : <select id="vmsconsole" name="CONSOLE">
   <?=mk_option($domain_cfg['CONSOLE'], 'web', _('Web interface'))?>
-  <?=mk_option($domain_cfg['CONSOLE'], 'remote', _('Virt-Manager Remove Viewer'))?>
-  <?=mk_option($domain_cfg['CONSOLE'], 'both', _('Both Web & Virt-Manager Remove Viewer'))?>
+  <?=mk_option($domain_cfg['CONSOLE'], 'remote', _('Virt-Manager Remote Viewer'))?>
+  <?=mk_option($domain_cfg['CONSOLE'], 'both', _('Both Web & Virt-Manager Remote Viewer'))?>
   </select>
 
 :vms_console_help:

--- a/plugins/dynamix.vm.manager/VMSettings.page
+++ b/plugins/dynamix.vm.manager/VMSettings.page
@@ -185,6 +185,15 @@ _(VM shutdown time-out)_:
 
 :vms_shutdown_timeout_help:
 
+_(Console Options)_:
+: <select id="vmsconsole" name="CONSOLE">
+  <?=mk_option($domain_cfg['CONSOLE'], 'web', _('Web interface'))?>
+  <?=mk_option($domain_cfg['CONSOLE'], 'remote', _('Virt-Manager Remove Viewer'))?>
+  <?=mk_option($domain_cfg['CONSOLE'], 'both', _('Both Web & Virt-Manager Remove Viewer'))?>
+  </select>
+
+:vms_console_help:
+
 _(PCIe ACS override)_:
 : <select id="pcie_acs_override"<?=$safemode?' disabled':''?>>
   <?= mk_option($pcie_acs_override, '', _('Disabled'))?>

--- a/plugins/dynamix.vm.manager/include/VMMachines.php
+++ b/plugins/dynamix.vm.manager/include/VMMachines.php
@@ -100,7 +100,8 @@ foreach ($vms as $vm) {
     $graphics = str_replace("\n", "<br>", trim($graphics));
   }
   unset($dom);
-  $menu = sprintf("onclick=\"addVMContext('%s','%s','%s','%s','%s','%s','%s')\"", addslashes($vm),addslashes($uuid),addslashes($template),$state,addslashes($vmrcurl),strtoupper($vmrcprotocol),addslashes($log));
+  if (!isset($domain_cfg["CONSOLE"])) $vmrcconsole = "web" ; else $vmrcconsole = $domain_cfg["CONSOLE"] ;
+  $menu = sprintf("onclick=\"addVMContext('%s','%s','%s','%s','%s','%s','%s','%s')\"", addslashes($vm),addslashes($uuid),addslashes($template),$state,addslashes($vmrcurl),strtoupper($vmrcprotocol),addslashes($log), $vmrcconsole);
   $kvm[] = "kvm.push({id:'$uuid',state:'$state'});";
   switch ($state) {
   case 'running':

--- a/plugins/dynamix.vm.manager/include/VMajax.php
+++ b/plugins/dynamix.vm.manager/include/VMajax.php
@@ -106,6 +106,45 @@ case 'domain-start-console':
 	$arrResponse['vmrcurl'] = $vmrcurl;
 	break;
 
+case 'domain-start-consoleRV':
+	requireLibvirt();
+	$arrResponse = $lv->domain_start($domName)
+	? ['success' => true, 'state' => $lv->domain_get_state($domName)]
+	: ['error' => $lv->get_last_error()];
+	$dom = $lv->get_domain_by_name($domName);
+	$vmrcport = $lv->domain_get_vnc_port($dom);
+	$wsport = $lv->domain_get_ws_port($dom);
+	$protocol = $lv->domain_get_vmrc_protocol($dom);
+	if ($protocol == "spice") $port= $vmrcport ; else $port=$vmrcport ;
+	$vvarray = array() ;
+	$vvarray[] = "[virt-viewer]\n";
+	$vvarray[] = "type=$protocol\n";
+	$vvarray[] = "host="._var($_SERVER,'HTTP_HOST')."\n" ;
+	$vvarray[] = "port=$port\n" ;
+	if (!is_dir("/mnt/user/system/remoteviewer")) mkdir("/mnt/user/system/remoteviewer") ;
+	$vvfile = "/mnt/user/system/remoteviewer/rv"._var($_SERVER,'HTTP_HOST').".$port.vv" ;
+	file_put_contents($vvfile,$vvarray) ;
+	$arrResponse['vvfile'] = $vvfile;
+	break;
+
+case 'domain-consoleRV':
+	requireLibvirt();
+	$dom = $lv->get_domain_by_name($domName);
+	$vmrcport = $lv->domain_get_vnc_port($dom);
+	$wsport = $lv->domain_get_ws_port($dom);
+	$protocol = $lv->domain_get_vmrc_protocol($dom);
+	if ($protocol == "spice") $port= $vmrcport ; else $port=$vmrcport ;
+	$vvarray = array() ;
+	$vvarray[] = "[virt-viewer]\n";
+	$vvarray[] = "type=$protocol\n";
+	$vvarray[] = "host="._var($_SERVER,'HTTP_HOST')."\n" ;
+	$vvarray[] = "port=$port\n" ;
+	if (!is_dir("/mnt/user/system/remoteviewer")) mkdir("/mnt/user/system/remoteviewer") ;
+	$vvfile = "/mnt/user/system/remoteviewer/rv"._var($_SERVER,'HTTP_HOST').".$port.vv" ;
+	file_put_contents($vvfile,$vvarray) ;
+	$arrResponse['vvfile'] = $vvfile;
+	break;
+	
 case 'domain-pause':
 	requireLibvirt();
 	$arrResponse = $lv->domain_suspend($domName)

--- a/plugins/dynamix.vm.manager/include/libvirt.php
+++ b/plugins/dynamix.vm.manager/include/libvirt.php
@@ -704,7 +704,6 @@
 											<binary path='/usr/libexec/virtiofsd'  xattr='on'>
 												<sandbox mode='chroot'/>
 												<cache mode='always'/>
-												<lock posix='on' flock='on'/>
 											</binary>
 										</filesystem>" ;
 					} else { 

--- a/plugins/dynamix.vm.manager/javascript/vmmanager.js
+++ b/plugins/dynamix.vm.manager/javascript/vmmanager.js
@@ -62,23 +62,26 @@ function ajaxVMDispatchconsoleRV(params, spin){
     }
   },'json');
 }
-function addVMContext(name, uuid, template, state, vmrcurl,vmrcprotocol , log){
+function addVMContext(name, uuid, template, state, vmrcurl, vmrcprotocol, log, console="web"){  
   var opts = [];
   var path = location.pathname;
   var x = path.indexOf("?");
   if (x!=-1) path = path.substring(0,x);
-  if (vmrcurl !== "" && state == "running") {
-    var vmrctext=_("VM Console") + "(" + vmrcprotocol + ")" ;
-    opts.push({text:vmrctext, icon:"fa-desktop", action:function(e) {
-      e.preventDefault();
-      window.open(vmrcurl, '_blank', 'scrollbars=yes,resizable=yes');
-    }});
-    if (vmrcurl !== "" && state == "running") {
-      opts.push({text:_("VM remote-viewer")+ "(" + vmrcprotocol + ")" , icon:"fa-desktop", action:function(e) {
+  if (vmrcurl !== "" && state == "running")  {
+    if (console == "web" || console == "both") {
+      var vmrctext=_("VM Console") + "(" + vmrcprotocol + ")" ;
+      opts.push({text:vmrctext, icon:"fa-desktop", action:function(e) {
         e.preventDefault();
-         ajaxVMDispatchconsoleRV({action:"domain-consoleRV", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
+        window.open(vmrcurl, '_blank', 'scrollbars=yes,resizable=yes');
       }});
     }
+    if (console == "remote" || console == "both") {
+      opts.push({text:_("VM remote-viewer")+ "(" + vmrcprotocol + ")" , icon:"fa-desktop", action:function(e) {
+        e.preventDefault();
+        ajaxVMDispatchconsoleRV({action:"domain-consoleRV", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
+      }});
+    }
+  
     opts.push({divider:true});
   }
   context.settings({right:false,above:false});
@@ -126,17 +129,18 @@ function addVMContext(name, uuid, template, state, vmrcurl,vmrcprotocol , log){
       e.preventDefault();
       ajaxVMDispatch({action:"domain-start", uuid:uuid}, "loadlist");
     }});
-    if (vmrcprotocol == "VNC" || vmrcprotocol == "SPICE")  {
-    opts.push({text:_("Start with console")+ "(" + vmrcprotocol + ")" , icon:"fa-play", action:function(e) {
-      e.preventDefault();
-       ajaxVMDispatchconsole({action:"domain-start-console", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
-    }});
-    if (vmrcprotocol == "VNC" || vmrcprotocol == "SPICE")  {
-      opts.push({text:_("Start with remote-viewer")+ "(" + vmrcprotocol + ")" , icon:"fa-play", action:function(e) {
-        e.preventDefault();
-         ajaxVMDispatchconsoleRV({action:"domain-start-consoleRV", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
-      }});
-    }
+    if (vmrcprotocol == "VNC" || vmrcprotocol == "SPICE") { 
+      if (console == "web" || console == "both")  {
+        opts.push({text:_("Start with console")+ "(" + vmrcprotocol + ")" , icon:"fa-play", action:function(e) {
+          e.preventDefault();
+          ajaxVMDispatchconsole({action:"domain-start-console", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
+        }});}
+      if (console == "remote" || console == "both")  {
+        opts.push({text:_("Start with remote-viewer")+ "(" + vmrcprotocol + ")" , icon:"fa-play", action:function(e) {
+          e.preventDefault();
+          ajaxVMDispatchconsoleRV({action:"domain-start-consoleRV", uuid:uuid, vmrcurl:vmrcurl}, "loadlist") ;  
+        }});
+      }
   }}
   opts.push({divider:true});
   if (log !== "") {

--- a/plugins/dynamix/include/DashboardApps.php
+++ b/plugins/dynamix/include/DashboardApps.php
@@ -110,7 +110,8 @@ if ($_POST['vms'] && ($display=='icons' || $display=='vms')) {
     $template = $lv->_get_single_xpath_result($res, '//domain/metadata/*[local-name()=\'vmtemplate\']/@name');
     if (empty($template)) $template = 'Custom';
     $log = (is_file("/var/log/libvirt/qemu/$vm.log") ? "libvirt/qemu/$vm.log" : '');
-    $menu = sprintf("onclick=\"addVMContext('%s','%s','%s','%s','%s','%s', '%s')\"", addslashes($vm), addslashes($uuid), addslashes($template), $state, addslashes($vmrcurl), strtoupper($vmrcprotocol), addslashes($log));
+    if (!isset($domain_cfg["CONSOLE"])) $vmrcconsole = "web" ; else $vmrcconsole = $domain_cfg["CONSOLE"] ;
+    $menu = sprintf("onclick=\"addVMContext('%s','%s','%s','%s','%s','%s','%s','%s')\"", addslashes($vm), addslashes($uuid), addslashes($template), $state, addslashes($vmrcurl), strtoupper($vmrcprotocol), addslashes($log), $vmrcconsole);
     $icon = $lv->domain_get_icon_url($res);
     switch ($state) {
     case 'running':


### PR DESCRIPTION
Remove lock posix and flock from virtiofsd options as QEMU V8 has dropped virtiofsd and the rust version need to be used going forwards but does not support these options.

https://gitlab.com/virtio-fs/virtiofsd/-/releases

Add support to start remote-viewer from the context menus. This will download a .vv file and if set in the browser will load remote-view will the .vv file.

![image](https://user-images.githubusercontent.com/39065407/233711135-cdccca45-01e5-4fdb-9b85-89313aabf487.png)
![image](https://user-images.githubusercontent.com/39065407/233711181-2ee82f6a-ee19-4fc4-8fd2-a035814f8e91.png)
![image](https://user-images.githubusercontent.com/39065407/233711219-9b612b61-1568-453b-9c12-28ecd5472777.png)
![image](https://user-images.githubusercontent.com/39065407/233711269-5021b87c-3421-467f-a281-063d0ee93075.png)
![image](https://user-images.githubusercontent.com/39065407/233711357-ee9a98e4-ad82-4d03-9608-b0f07dfeffe4.png)

Please review and let me know any feedback.