### PR TITLE
rc scripts: use common library source

### DIFF
--- a/emhttp/plugins/dynamix/scripts/show_interfaces
+++ b/emhttp/plugins/dynamix/scripts/show_interfaces
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT="show"
+CALLER="show"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/emhttp/plugins/dynamix/scripts/show_interfaces
+++ b/emhttp/plugins/dynamix/scripts/show_interfaces
@@ -1,99 +1,21 @@
 #!/bin/bash
 
+SCRIPT="show"
 NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
-zero() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && data=$1
-  done
-  echo $data
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} ]]; then
-      # net is an interface name, validate
-      [[ -n $(show dev $net) && -z $(zero $net) ]] && bind+=($net)
-    else
-      # net is an IP address, convert to name
-      net=$(show $net)
-      [[ -n $net && -z $(zero $net) ]] && bind+=($net)
-    fi
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} ]]; then
-      # net is an interface name, remove
-      remove $net
-    else
-      # net is an IP address, convert to name and remove
-      remove $(show $net)
-    fi
-  done
-}
-
-bind=();
-if [[ -f $NETWORK_INI ]]; then
-  # get interface and vlan configurations
-  for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-    # main interface
-    if [[ -e $SYSTEM/$eth ]]; then
-      sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-      net=$eth
-      [[ $(link BONDING) == yes ]] && net=${eth/eth/bond}
-      [[ $(link BRIDGING) == yes ]] && net=${eth/eth/br}
-      net4=$(link IPADDR:0)
-      net6=$(link IPADDR6:0)
-      [[ -n $net4 || -n $net6 ]] && bind+=($net)
-      if [[ $(link TYPE) == trunk ]]; then
-        # vlan interface
-        for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-          net4=$(link IPADDR:$vlan)
-          net6=$(link IPADDR6:$vlan)
-          [[ -n $net4 || -n $net6 ]] && bind+=($net.$vlan)
-        done
-      fi
-    fi
-  done
-  # add active WG tunnels
-  for wg in $(wg show interfaces); do
-    net4=$(show -4 dev $wg)
-    net6=$(show -6 dev $wg)
-    [[ -n $net4 || -n $net6 ]] && bind+=($wg)
-  done
-  # add user defined interfaces
-  [[ -f $EXTRA ]] && extra
-  # remove temporary file
-  rm -f $NETWORK_INI.eth
-fi
-bind=${bind[@]}
-if [[ $1 == ip ]]; then
+# include IP addresses?
+if check && [[ $1 == ip ]]; then
   ip=()
   for net in $bind; do
     ip+=("$net#[$(show -4 dev $net)#$(show -6 dev $net)]")
   done
   bind=${ip[@]}
 fi
+
+# return list
 echo ${bind// /, }

--- a/emhttp/plugins/dynamix/scripts/show_interfaces
+++ b/emhttp/plugins/dynamix/scripts/show_interfaces
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 SCRIPT="show"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.apcupsd
+++ b/etc/rc.d/rc.apcupsd
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 #
 # apcupsd      This shell script takes care of starting and stopping
 #	       the apcupsd UPS monitoring daemon.

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -22,7 +22,7 @@
 
 # Start/stop/restart the avahi daemon:
 
-SCRIPT="avahi"
+CALLER="avahi"
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Avahi mDNS/DNS-SD Daemon"
 AVAHI="/usr/sbin/avahi-daemon"
@@ -87,7 +87,7 @@ avahid_reload() {
 
 avahid_update() {
   if ! avahid_status; then exit 1; fi # not running
-  if check && [[ "$(this allow-interfaces)" == "$bind" && $(this use-ipv4) == $ipv4 && $(this use-ipv6) == $ipv6 ]]; then
+  if check && [[ "$(this allow-interfaces)" == "$bind" ]]; then
     # no action required
     exit 1
   else

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -47,7 +47,7 @@ avahid_start() {
   if [[ -f $NETWORK_INI ]]; then
     # bind avahi service
     if check; then
-      [[ -n $bind ]] && allow $bind
+      [[ -n $bind ]] && allow $bind || allow br0
       [[ $ipv4 == yes ]] && enable ipv4 || disable ipv4
       [[ $ipv6 == yes ]] && enable ipv6 || disable ipv6
     fi

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -27,10 +27,6 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Avahi mDNS/DNS-SD Daemon"
 AVAHI="/usr/sbin/avahi-daemon"
 CONF="/etc/avahi/avahi-daemon.conf"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#
 # This file is part of avahi.
 #
 # avahi is free software; you can redistribute it and/or modify it
@@ -14,8 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with avahi; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
-# USA.
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 # limetech - 'status' modified to exit with correct status
 # limetech - 'start' modified to enable/disable ipv4/ipv6
@@ -23,6 +22,7 @@
 
 # Start/stop/restart the avahi daemon:
 
+SCRIPT="avahi"
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Avahi mDNS/DNS-SD Daemon"
 AVAHI="/usr/sbin/avahi-daemon"
@@ -32,49 +32,8 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Pom1 "^$1=\K.*" $CONF
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 allow() {
   sed -ri "s/^#?(allow-interfaces)=.*/\1=$*/" $CONF
@@ -86,80 +45,6 @@ enable() {
 
 disable() {
   sed -ri "s/^#?(use-$1)=.*/\1=no/" $CONF
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, validate
-      [[ -n $(show dev $net) && -z $(take $net) ]] && bind+=($net)
-    else
-      # net is an IP address, convert to name
-      net=$(show $net)
-      [[ -n $net && -z $(take $net) ]] && bind+=($net)
-    fi
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, remove
-      remove $net
-    else
-      # net is an IP address, convert to name and remove
-      remove $(show $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no;
-  if [[ -f $NETWORK_INI ]]; then
-    # get interface and vlan configurations
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      # main interface
-      if [[ -e $SYSTEM/$eth ]]; then
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net=$eth
-        [[ $(link BONDING) == yes ]] && net=${eth/eth/bond}
-        [[ $(link BRIDGING) == yes ]] && net=${eth/eth/br}
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($net)
-        [[ -n $(good $net4) ]] && ipv4=yes
-        [[ -n $(good $net6) ]] && ipv6=yes
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($net.$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes
-            [[ -n $(good $net6) ]] && ipv6=yes
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($wg)
-      [[ -n $(good $net4) ]] && ipv4=yes
-      [[ -n $(good $net6) ]] && ipv6=yes
-    done
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string with commas
-    bind=${bind[@]}
-    bind=${bind// /,}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
 }
 
 avahid_start() {

--- a/etc/rc.d/rc.avahidaemon
+++ b/etc/rc.d/rc.avahidaemon
@@ -48,8 +48,8 @@ avahid_start() {
     # bind avahi service
     if check; then
       [[ -n $bind ]] && allow $bind || allow br0
-      [[ $ipv4 == yes ]] && enable ipv4 || disable ipv4
-      [[ $ipv6 == yes ]] && enable ipv6 || disable ipv6
+      [[ $ipv4 == no ]] && disable ipv4 || enable ipv4
+      [[ $ipv6 == no ]] && disable ipv6 || enable ipv6
     fi
   else
     # default interface with no configuration

--- a/etc/rc.d/rc.inet1
+++ b/etc/rc.d/rc.inet1
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # /etc/rc.d/rc.inet1
 # This script is used to bring up the various network interfaces.
 #
@@ -45,13 +45,14 @@
 # Adapted by Bergware for use in unRAID - May 2023
 # - added iptables and ip6tables and arp-tables inclusion to bridge interfaces
 # - fixed ipv4 and ipv6 DNS assignment
+# - suppress errors
 
 ############################
 # READ NETWORK CONFIG FILE #
 ############################
 
 # get the configuration information from rc.inet1.conf
-source /etc/rc.d/rc.inet1.conf
+. /etc/rc.d/rc.inet1.conf
 
 # system network reference
 SYSTEM=/sys/class/net
@@ -69,7 +70,7 @@ alias log=run
 run(){
   # log command in /var/log/syslog and execute
   logger -t rc.inet1 "$*"
-  [[ -n $2 ]] && $*
+  [[ -n $2 ]] && $* 2>/dev/null
 }
 
 ############################

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -126,11 +126,7 @@ extra_addr() {
 
 extra() {
   source <(/usr/bin/fromdos <$EXTRA)
-  if [[ "avahi show" =~ $CALLER ]]; then
-    extra_name
-  else
-    extra_addr
-  fi
+  [[ "avahi show" =~ $CALLER ]] && extra_name || extra_addr
 }
 
 check() {

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -11,7 +11,7 @@ this() {
   'avahi')
     grep -Pom1 "^$1=\K.*" $CONF
     ;;
-  'samba')
+  'smb')
     grep -Pom1 "^$1 = \K.*" $CONF
     ;;
   'ntp'|'ssh')

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -8,31 +8,31 @@ EXTRA="/boot/config/network-extra.cfg"
 
 this() {
   case $CALLER in
-'avahi')
-  grep -Pom1 "^$1=\K.*" $CONF
-  ;;
-'samba')
-  grep -Pom1 "^$1 = \K.*" $CONF
-  ;;
-'ntpd'|'sshd')
-  grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
-  ;;
-'nfsd')
-  grep -Pom1 "^RPC_NFSD_OPTS=\"$OPTIONS \K[^\"]+" $NFS
-  ;;
-'rpc')
-  grep -Pom1 "^RPCBIND_OPTS=\"\K[^\"]+" $RPC
-  ;;
-'nginx')
-  now=();
-  for addr in $(awk '$1=="listen" && $2~/^[0-9]|\[/ && $0~/http2; #.*$/{print $2}' $SERVERS 2>/dev/null); do
-    # extract ipv4 / ipv6 address
-    [[ $(IPv $addr 1) == 4 ]] && addr=${addr%:*} || addr=${addr#*[} addr=${addr%]*}
-    now+=($addr)
-  done
-  # return addresses
-  echo ${now[@]}
-  ;;
+  'avahi')
+    grep -Pom1 "^$1=\K.*" $CONF
+    ;;
+  'samba')
+    grep -Pom1 "^$1 = \K.*" $CONF
+    ;;
+  'ntpd'|'sshd')
+    grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
+    ;;
+  'nfsd')
+    grep -Pom1 "^RPC_NFSD_OPTS=\"$OPTIONS \K[^\"]+" $NFS
+    ;;
+  'rpc')
+    grep -Pom1 "^RPCBIND_OPTS=\"\K[^\"]+" $RPC
+    ;;
+  'nginx')
+    now=();
+    for addr in $(awk '$1=="listen" && $2~/^[0-9]|\[/ && $0~/http2; #.*$/{print $2}' $SERVERS 2>/dev/null); do
+      # extract ipv4 / ipv6 address
+      [[ $(IPv $addr 1) == 4 ]] && addr=${addr%:*} || addr=${addr#*[} addr=${addr%]*}
+      now+=($addr)
+    done
+    # return addresses
+    echo ${now[@]}
+    ;;
   esac
 }
 

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -7,7 +7,7 @@ SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
 this() {
-  case $SCRIPT in
+  case $CALLER in
 'avahi')
   grep -Pom1 "^$1=\K.*" $CONF
   ;;
@@ -76,63 +76,68 @@ remove() {
   done
 }
 
+extra_name() {
+  for net in $include_interfaces; do
+    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+      # net is an interface name, validate
+      [[ -n $(show dev $net) && -z $(take $net) ]] && bind+=($net)
+    else
+      # net is an IP address, convert to name
+      net=$(show $net)
+      [[ -n $net && -z $(take $net) ]] && bind+=($net)
+    fi
+  done
+  for net in $exclude_interfaces; do
+    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+      # net is an interface name, remove
+      remove $net
+    else
+      # net is an IP address, convert to name and remove
+      remove $(show $net)
+    fi
+  done
+}
+
+extra_addr() {
+  for net in $include_interfaces; do
+    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+      # net is an interface name, get IP addresses
+      net4=$(show -4 dev $net)
+      net6=$(show -6 dev $net)
+    else
+      # net is an IP address, validate
+      net4=$(show -4 to $net)
+      net6=$(show -6 to $net)
+    fi
+    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
+    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
+  done
+  for net in $exclude_interfaces; do
+    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+      # net is an interface name, get IP addresses
+      remove $(show -4 dev $net)
+      remove $(show -6 dev $net)
+    else
+      # net is an IP address
+      remove $(show to $net)
+    fi
+  done
+}
+
 extra() {
   source <(/usr/bin/fromdos <$EXTRA)
-  case $SCRIPT in
-  'avahi'|'show')
-    for net in $include_interfaces; do
-      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-        # net is an interface name, validate
-        [[ -n $(show dev $net) && -z $(take $net) ]] && bind+=($net)
-      else
-        # net is an IP address, convert to name
-        net=$(show $net)
-        [[ -n $net && -z $(take $net) ]] && bind+=($net)
-      fi
-    done
-    for net in $exclude_interfaces; do
-      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-        # net is an interface name, remove
-        remove $net
-      else
-        # net is an IP address, convert to name and remove
-        remove $(show $net)
-      fi
-    done
-    ;;
-  *)
-    for net in $include_interfaces; do
-      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-        # net is an interface name, get IP addresses
-        net4=$(show -4 dev $net)
-        net6=$(show -6 dev $net)
-      else
-        # net is an IP address, validate
-        net4=$(show -4 to $net)
-        net6=$(show -6 to $net)
-      fi
-      [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-      [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-    done
-    for net in $exclude_interfaces; do
-      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-        # net is an interface name, get IP addresses
-        remove $(show -4 dev $net)
-        remove $(show -6 dev $net)
-      else
-        # net is an IP address
-        remove $(show to $net)
-      fi
-    done
-    ;;
-  esac
+  if [[ "avahi show" =~ $CALLER ]]; then
+    extra_name
+  else
+    extra_addr
+  fi
 }
 
 check() {
   # quick check
   [[ -n $bind ]] && return 0;
   # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no;
+  reply=1; bind=(); ipv4=no; ipv6=no; family=any;
   if [[ -f $NETWORK_INI ]]; then
     # add interfaces and vlans
     for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
@@ -141,7 +146,7 @@ check() {
         sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
         net4=$(link IPADDR:0)
         net6=$(link IPADDR6:0)
-        if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+        if [[ "avahi show" =~ $CALLER ]]; then
           net=$eth
           [[ $(link BONDING) == yes ]] && net=${eth/eth/bond}
           [[ $(link BRIDGING) == yes ]] && net=${eth/eth/br}
@@ -157,7 +162,7 @@ check() {
           for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
             net4=$(link IPADDR:$vlan)
             net6=$(link IPADDR6:$vlan)
-            if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+            if [[ "avahi show" =~ $CALLER ]]; then
               [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($net.$(link VLANID:$vlan))
               [[ -n $(good $net4) ]] && ipv4=yes
               [[ -n $(good $net6) ]] && ipv6=yes
@@ -173,7 +178,7 @@ check() {
     for wg in $(wg show interfaces); do
       net4=$(show -4 dev $wg)
       net6=$(show -6 dev $wg)
-      if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+      if [[ "avahi show" =~ $CALLER ]]; then
         [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($wg)
         [[ -n $(good $net4) ]] && ipv4=yes
         [[ -n $(good $net6) ]] && ipv6=yes
@@ -183,13 +188,13 @@ check() {
       fi
     done
     # add loopback interface
-    if [[ "nfsd ntpd rpc" =~ $SCRIPT ]]; then
+    if [[ "nfsd ntpd rpc" =~ $CALLER ]]; then
       [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
       [[ $ipv6 == yes ]] && bind+=(::1)
     fi
     # add user defined interfaces
     [[ -f $EXTRA ]] && extra
-    if [[ $SCRIPT == sshd ]]; then
+    if [[ $CALLER == sshd ]]; then
       # bind stays array
       bind=(${bind[@]})
       [[ $ipv4 == yes && $ipv6 == no ]] && family=inet
@@ -197,7 +202,7 @@ check() {
     else
       # convert array to string
       bind=${bind[@]}
-      [[ $SCRIPT == avahi ]] && bind=${bind// /,}
+      [[ $CALLER == avahi ]] && bind=${bind// /,}
     fi
     reply=0
     # remove temporary file

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -129,7 +129,7 @@ extra_addr() {
 }
 
 extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
+  . <(/usr/bin/fromdos <$EXTRA)
   if [[ "avahi show" =~ $CALLER ]]; then
     extra_name
   else

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -126,7 +126,11 @@ extra_addr() {
 
 extra() {
   source <(/usr/bin/fromdos <$EXTRA)
-  [[ "avahi show" =~ $CALLER ]] && extra_name || extra_addr
+  if [[ "avahi show" =~ $CALLER ]]; then
+    extra_name
+  else
+    extra_addr
+  fi
 }
 
 check() {

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -192,13 +192,13 @@ check() {
       fi
     done
     # add loopback interface
-    if [[ "nfsd ntpd rpc" =~ $CALLER ]]; then
+    if [[ "nfs ntp rpc" =~ $CALLER ]]; then
       [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
       [[ $ipv6 == yes ]] && bind+=(::1)
     fi
     # add user defined interfaces
     [[ -f $EXTRA ]] && extra
-    if [[ $CALLER == sshd ]]; then
+    if [[ $CALLER == ssh ]]; then
       # bind stays array
       bind=(${bind[@]})
       [[ $ipv4 == yes && $ipv6 == no ]] && family=inet

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -76,9 +76,13 @@ remove() {
   done
 }
 
+isname() {
+  [[ -z ${1//[^.:]} || ${1//[^.:]} == . ]] && return 0 || return 1
+}
+
 extra_name() {
   for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+    if $(isname $net); then
       # net is an interface name, validate
       [[ -n $(show dev $net) && -z $(take $net) ]] && bind+=($net)
     else
@@ -88,7 +92,7 @@ extra_name() {
     fi
   done
   for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+    if $(isname $net); then
       # net is an interface name, remove
       remove $net
     else
@@ -100,7 +104,7 @@ extra_name() {
 
 extra_addr() {
   for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+    if $(isname $net); then
       # net is an interface name, get IP addresses
       net4=$(show -4 dev $net)
       net6=$(show -6 dev $net)
@@ -113,7 +117,7 @@ extra_addr() {
     [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
   done
   for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+    if $(isname $net); then
       # net is an interface name, get IP addresses
       remove $(show -4 dev $net)
       remove $(show -6 dev $net)

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -1,0 +1,202 @@
+# /etc/rc.d/rc.library
+# used by nfsd, ntpd, rpc, samba, nginx, sshd, avahidaemon, show_interfaces
+
+this() {
+  case $SCRIPT in
+'avahi')
+  grep -Pom1 "^$1=\K.*" $CONF
+  ;;
+'samba')
+  grep -Pom1 "^$1 = \K.*" $CONF
+  ;;
+'ntpd'|'sshd')
+  grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
+  ;;
+'nfsd')
+  grep -Pom1 "^RPC_NFSD_OPTS=\"$OPTIONS \K[^\"]+" $NFS
+  ;;
+'rpc')
+  grep -Pom1 "^RPCBIND_OPTS=\"\K[^\"]+" $RPC
+  ;;
+'nginx')
+  now=();
+  for addr in $(awk '$1=="listen" && $2~/^[0-9]|\[/ && $0~/http2; #.*$/{print $2}' $SERVERS 2>/dev/null); do
+    # extract ipv4 / ipv6 address
+    [[ $(IPv $addr 1) == 4 ]] && addr=${addr%:*} || addr=${addr#*[} addr=${addr%]*}
+    now+=($addr)
+  done
+  # return addresses
+  echo ${now[@]}
+  ;;
+  esac
+}
+
+IPv() {
+  type=${1//[^:]}
+  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
+}
+
+scan() {
+  grep -Pom1 "^$1=\"?\K[^\"]+" $2
+}
+
+link() {
+  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
+}
+
+take() {
+  data=;
+  for i in ${!bind[@]}; do
+    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
+  done
+  echo $data
+}
+
+good() {
+  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
+}
+
+show() {
+  case $# in
+    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
+    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
+    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
+  esac
+}
+
+remove() {
+  [[ $# -eq 0 ]] && return
+  for i in ${!bind[@]}; do
+    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
+  done
+}
+
+extra() {
+  source <(/usr/bin/fromdos <$EXTRA)
+  case $SCRIPT in
+  'avahi'|'show')
+    for net in $include_interfaces; do
+      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+        # net is an interface name, validate
+        [[ -n $(show dev $net) && -z $(take $net) ]] && bind+=($net)
+      else
+        # net is an IP address, convert to name
+        net=$(show $net)
+        [[ -n $net && -z $(take $net) ]] && bind+=($net)
+      fi
+    done
+    for net in $exclude_interfaces; do
+      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+        # net is an interface name, remove
+        remove $net
+      else
+        # net is an IP address, convert to name and remove
+        remove $(show $net)
+      fi
+    done
+    ;;
+  *)
+    for net in $include_interfaces; do
+      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+        # net is an interface name, get IP addresses
+        net4=$(show -4 dev $net)
+        net6=$(show -6 dev $net)
+      else
+        # net is an IP address, validate
+        net4=$(show -4 to $net)
+        net6=$(show -6 to $net)
+      fi
+      [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
+      [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
+    done
+    for net in $exclude_interfaces; do
+      if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
+        # net is an interface name, get IP addresses
+        remove $(show -4 dev $net)
+        remove $(show -6 dev $net)
+      else
+        # net is an IP address
+        remove $(show to $net)
+      fi
+    done
+    ;;
+  esac
+}
+
+check() {
+  # quick check
+  [[ -n $bind ]] && return 0;
+  # preset return values
+  reply=1; bind=(); ipv4=no; ipv6=no;
+  if [[ -f $NETWORK_INI ]]; then
+    # add interfaces and vlans
+    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
+      if [[ -e $SYSTEM/$eth ]]; then
+        # main interface
+        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
+        net4=$(link IPADDR:0)
+        net6=$(link IPADDR6:0)
+        if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+          net=$eth
+          [[ $(link BONDING) == yes ]] && net=${eth/eth/bond}
+          [[ $(link BRIDGING) == yes ]] && net=${eth/eth/br}
+          [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($net)
+          [[ -n $(good $net4) ]] && ipv4=yes
+          [[ -n $(good $net6) ]] && ipv6=yes
+        else
+          [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
+          [[ -n $(good $net6) && -z $deny6 ]] && ipv6=yes bind+=($net6)
+        fi
+        if [[ $(link TYPE) == trunk ]]; then
+          # vlan interface
+          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
+            net4=$(link IPADDR:$vlan)
+            net6=$(link IPADDR6:$vlan)
+            if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+              [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($net.$(link VLANID:$vlan))
+              [[ -n $(good $net4) ]] && ipv4=yes
+              [[ -n $(good $net6) ]] && ipv6=yes
+            else
+              [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
+              [[ -n $(good $net6) && -z $deny6 ]] && ipv6=yes bind+=($net6)
+            fi
+          done
+        fi
+      fi
+    done
+    # add active WG tunnels
+    for wg in $(wg show interfaces); do
+      net4=$(show -4 dev $wg)
+      net6=$(show -6 dev $wg)
+      if [[ $SCRIPT == avahi || $SCRIPT == show ]]; then
+        [[ -n $(good $net4) || -n $(good $net6) ]] && bind+=($wg)
+        [[ -n $(good $net4) ]] && ipv4=yes
+        [[ -n $(good $net6) ]] && ipv6=yes
+      else
+        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
+        [[ -n $(good $net6) && -z $deny6 ]] && ipv6=yes bind+=($net6)
+      fi
+    done
+    # add loopback interface
+    if [[ "nfsd ntpd rpc" =~ $SCRIPT ]]; then
+      [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
+      [[ $ipv6 == yes ]] && bind+=(::1)
+    fi
+    # add user defined interfaces
+    [[ -f $EXTRA ]] && extra
+    if [[ $SCRIPT == sshd ]]; then
+      # bind stays array
+      bind=(${bind[@]})
+      [[ $ipv4 == yes && $ipv6 == no ]] && family=inet
+      [[ $ipv6 == yes && $ipv4 == no ]] && family=inet6
+    else
+      # convert array to string
+      bind=${bind[@]}
+      [[ $SCRIPT == avahi ]] && bind=${bind// /,}
+    fi
+    reply=0
+    # remove temporary file
+    rm -f $NETWORK_INI.eth
+  fi
+  return $reply
+}

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -14,10 +14,10 @@ this() {
   'samba')
     grep -Pom1 "^$1 = \K.*" $CONF
     ;;
-  'ntpd'|'sshd')
+  'ntp'|'ssh')
     grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
     ;;
-  'nfsd')
+  'nfs')
     grep -Pom1 "^RPC_NFSD_OPTS=\"$OPTIONS \K[^\"]+" $NFS
     ;;
   'rpc')

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -1,6 +1,11 @@
 # /etc/rc.d/rc.library
 # used by nfsd, ntpd, rpc, samba, nginx, sshd, avahidaemon, show_interfaces
 
+WIREGUARD="/etc/wireguard"
+NETWORK_INI="/var/local/emhttp/network.ini"
+SYSTEM="/sys/class/net"
+EXTRA="/boot/config/network-extra.cfg"
+
 this() {
   case $SCRIPT in
 'avahi')

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -1,5 +1,5 @@
-# /etc/rc.d/rc.library
-# used by nfsd, ntpd, rpc, samba, nginx, sshd, avahidaemon, show_interfaces
+# Library file: /etc/rc.d/rc.library.source
+# Used by nfsd, ntpd, rpc, samba, nginx, sshd, avahidaemon, show_interfaces
 
 WIREGUARD="/etc/wireguard"
 NETWORK_INI="/var/local/emhttp/network.ini"

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -9,7 +9,7 @@
 #
 # bergware - added interface bind functionality
 
-CALLER="nfsd"
+CALLER="nfs"
 NFSD="/usr/sbin/rpc.nfsd"
 EXPORTFS="/usr/sbin/exportfs"
 RQUOTAD="/usr/sbin/rpc.rquotad"

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -17,10 +17,6 @@ MOUNTD="/usr/sbin/rpc.mountd"
 OPTIONS="-u -s"
 RPC="/etc/default/rpc"
 NFS="/etc/default/nfs"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -9,6 +9,7 @@
 #
 # bergware - added interface bind functionality
 
+SCRIPT="nfsd"
 NFSD="/usr/sbin/rpc.nfsd"
 EXPORTFS="/usr/sbin/exportfs"
 RQUOTAD="/usr/sbin/rpc.rquotad"
@@ -21,123 +22,8 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Pom1 "^RPC_NFSD_OPTS=\"$OPTIONS \K[^\"]+" $NFS
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=();
-  if [[ -f $NETWORK_INI ]]; then
-    # add interfaces and vlans
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      if [[ -e $SYSTEM/$eth ]]; then
-        # main interface
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-    done
-    # add loopback interface
-    [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
-    [[ $ipv6 == yes ]] && bind+=(::1)
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string
-    bind=${bind[@]}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 # get bind addresses
 if check && [[ -n $bind ]]; then
@@ -162,14 +48,12 @@ nfsd_start() {
   if [[ ! -r /proc/1/net/rpc/nfsd ]]; then
     /sbin/modprobe nfsd 2>/dev/null
   fi
-
   # mount the nfsd filesystem:
   if awk '$NF == "nfsd"' /proc/filesystems | grep -q . ; then
     if ! awk '$3 == "nfsd" && $2 == "/proc/fs/nfs"' /proc/mounts | grep -q . ; then
       /sbin/mount -t nfsd nfsd /proc/fs/nfs 2>/dev/null
     fi
   fi
-
   # if basic RPC services are not running, start them:
   if ! ps axc | grep -q rpc.statd; then
     if [[ -r /etc/rc.d/rc.rpc ]]; then
@@ -181,27 +65,22 @@ nfsd_start() {
       exit 1
     fi
   fi
-
   echo "Starting NFS server daemons:"
-
   if [[ -x $EXPORTFS ]]; then
     echo "  $EXPORTFS -r"
     $EXPORTFS -r 2>/dev/null
   fi
-
   if [[ -x $RQUOTAD ]]; then
     [[ -n $RPC_RQUOTAD_PORT ]] && RPC_RQUOTAD_OPTS="$RPC_RQUOTAD_OPTS -p $RPC_RQUOTAD_PORT"
     echo "  $RQUOTAD $RPC_RQUOTAD_OPTS"
     $RQUOTAD $RPC_RQUOTAD_OPTS 2>/dev/null
   fi
-
   # start nfsd servers - 8 if not set extrawise (an old Sun standard):
   if [[ -x $NFSD ]]; then
     [[ -z $RPC_NFSD_COUNT ]] && RPC_NFSD_COUNT=8
     echo "  $NFSD $RPC_NFSD_OPTS $RPC_NFSD_COUNT"
     $NFSD $RPC_NFSD_OPTS $RPC_NFSD_COUNT 2>/dev/null
   fi
-
   if [[ -x $MOUNTD ]]; then
     [[ -n $RPC_MOUNTD_PORT ]] && RPC_MOUNTD_OPTS="$RPC_MOUNTD_OPTS -p $RPC_MOUNTD_PORT"
     echo "  $MOUNTD $RPC_MOUNTD_OPTS"

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -9,7 +9,7 @@
 #
 # bergware - added interface bind functionality
 
-SCRIPT="nfsd"
+CALLER="nfsd"
 NFSD="/usr/sbin/rpc.nfsd"
 EXPORTFS="/usr/sbin/exportfs"
 RQUOTAD="/usr/sbin/rpc.rquotad"

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -61,9 +61,9 @@ listen() {
   t='    '
   if [[ $1 == lo ]]; then
     echo "${t}listen 127.0.0.1:$PORT; # lo"
-    [[ $USE_SSL != no ]] && echo "${t}listen 127.0.0.1:$PORTSSL; # lo"
+    echo "${t}listen 127.0.0.1:$PORTSSL; # lo"
     echo "${t}listen [::1]:$PORT; # lo"
-    [[ $USE_SSL != no ]] && echo "${t}listen [::1]:$PORTSSL; # lo"
+    echo "${t}listen [::1]:$PORTSSL; # lo"
   elif check && [[ -n $bind ]]; then
     for addr in $bind; do
       [[ $(IPv $addr) == 4 ]] && echo "${t}listen $addr:$*; # $(show $addr)"

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -15,6 +15,7 @@
 # WANFQDN       'www.hash.unraid.net'  (legacy)
 # WG0FQDN  'wg0-ip.hash.myunraid.net'  (wildcard cert)
 
+SCRIPT="nginx"
 NGINX="/usr/sbin/nginx"
 PID="/var/run/nginx.pid"
 SSL="/boot/config/ssl"
@@ -33,10 +34,8 @@ EXTRA="/boot/config/network-extra.cfg"
 # hold server names
 SERVER_NAMES=()
 
-# read settings
-if [[ -a $IDENT ]]; then
-  source <(/usr/bin/fromdos <$IDENT)
-fi
+# read Unraid settings
+[[ -r $IDENT ]] && . <(/usr/bin/fromdos <$IDENT)
 
 # preset default values
 [[ -z $START_PAGE ]] && START_PAGE=Main
@@ -54,130 +53,11 @@ if ! find /boot/config/*.key &>/dev/null; then
   START_PAGE="Tools/Registration"
 fi
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  now=();
-  for addr in $(awk '$1=="listen" && $2~/^[0-9]|\[/ && $0~/http2;$/{print $2}' $SERVERS 2>/dev/null); do
-    # extract ipv4 / ipv6 address
-    [[ $(IPv $addr 1) == 4 ]] && addr=${addr%:*} || addr=${addr#*[} addr=${addr%]*}
-    now+=($addr)
-  done
-  # return addresses
-  echo ${now[@]}
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 fqdn() {
   echo ${CERTNAME/'*'/${1//[.:]/-}}
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no;
-  if [[ -f $NETWORK_INI ]]; then
-    # add interfaces and vlans
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      if [[ -e $SYSTEM/$eth ]]; then
-        # main interface
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-    done
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string
-    bind=${bind[@]}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
 }
 
 # create listening ports

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -23,7 +23,7 @@ CONF="/etc/nginx/nginx.conf"
 IDENT="/boot/config/ident.cfg"
 SERVERS="/etc/nginx/conf.d/servers.conf"
 LOCATIONS="/etc/nginx/conf.d/locations.conf"
-NEW="/var/local/emhttp/nginx.ini.new"
+INI="/var/local/emhttp/nginx.ini.new"
 CERTPATH="$SSL/certs/certificate_bundle.pem"
 MYSERVERS="/boot/config/plugins/dynamix.my.servers/myservers.cfg"
 
@@ -541,36 +541,36 @@ build_ssl() {
     DEFAULTURL="http://$LANMDNS$PORT_URL"
   fi
 
-  mkdir -p $(dirname "$NEW")
+  mkdir -p $(dirname "$INI")
   # always defined:
-  echo "NGINX_LANIP=\"$LANIP\"" >$NEW
-  echo "NGINX_LANIP6=\"$LANIP6\"" >>$NEW
-  echo "NGINX_LANNAME=\"$LANNAME\"" >>$NEW
-  echo "NGINX_LANMDNS=\"$LANMDNS\"" >>$NEW
-  echo "NGINX_CERTPATH=\"$CERTPATH\"" >>$NEW
-  echo "NGINX_USESSL=\"$USE_SSL\"" >>$NEW
-  echo "NGINX_PORT=\"$PORT\"" >>$NEW
-  echo "NGINX_PORTSSL=\"$PORTSSL\"" >>$NEW
-  echo "NGINX_DEFAULTURL=\"$DEFAULTURL\"" >>$NEW
+  echo "NGINX_LANIP=\"$LANIP\"" >$INI
+  echo "NGINX_LANIP6=\"$LANIP6\"" >>$INI
+  echo "NGINX_LANNAME=\"$LANNAME\"" >>$INI
+  echo "NGINX_LANMDNS=\"$LANMDNS\"" >>$INI
+  echo "NGINX_CERTPATH=\"$CERTPATH\"" >>$INI
+  echo "NGINX_USESSL=\"$USE_SSL\"" >>$INI
+  echo "NGINX_PORT=\"$PORT\"" >>$INI
+  echo "NGINX_PORTSSL=\"$PORTSSL\"" >>$INI
+  echo "NGINX_DEFAULTURL=\"$DEFAULTURL\"" >>$INI
   # defined if certificate_bundle.pem present:
-  echo "NGINX_CERTNAME=\"$CERTNAME\"" >>$NEW
-  echo "NGINX_LANFQDN=\"$LANFQDN\"" >>$NEW
-  echo "NGINX_LANFQDN6=\"$LANFQDN6\"" >>$NEW
+  echo "NGINX_CERTNAME=\"$CERTNAME\"" >>$INI
+  echo "NGINX_LANFQDN=\"$LANFQDN\"" >>$INI
+  echo "NGINX_LANFQDN6=\"$LANFQDN6\"" >>$INI
   # defined if remote access enabled:
-  echo "NGINX_WANACCESS=\"$WANACCESS\"" >>$NEW
-  echo "NGINX_WANIP=\"$WANIP\"" >>$NEW
-  echo "NGINX_WANIP6=\"$WANIP6\"" >>$NEW
-  echo "NGINX_WANFQDN=\"$WANFQDN\"" >>$NEW
-  echo "NGINX_WANFQDN6=\"$WANFQDN6\"" >>$NEW
+  echo "NGINX_WANACCESS=\"$WANACCESS\"" >>$INI
+  echo "NGINX_WANIP=\"$WANIP\"" >>$INI
+  echo "NGINX_WANIP6=\"$WANIP6\"" >>$INI
+  echo "NGINX_WANFQDN=\"$WANFQDN\"" >>$INI
+  echo "NGINX_WANFQDN6=\"$WANFQDN6\"" >>$INI
   # add included interfaces
   for NET in ${!NET_FQDN[@]}; do
-    echo "NGINX_${NET^^}FQDN=\"${NET_FQDN[$NET]}\"" >>$NEW
+    echo "NGINX_${NET^^}FQDN=\"${NET_FQDN[$NET]}\"" >>$INI
   done
   for NET in ${!NET_FQDN6[@]}; do
-    echo "NGINX_${NET^^}FQDN6=\"${NET_FQDN6[$NET]}\"" >>$NEW
+    echo "NGINX_${NET^^}FQDN6=\"${NET_FQDN6[$NET]}\"" >>$INI
   done
   # atomically update file
-  /usr/bin/mv $NEW ${NEW%.*}
+  /usr/bin/mv $INI ${INI%.*}
 }
 
 nginx_status() {

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -15,7 +15,7 @@
 # WANFQDN       'www.hash.unraid.net'  (legacy)
 # WG0FQDN  'wg0-ip.hash.myunraid.net'  (wildcard cert)
 
-SCRIPT="nginx"
+CALLER="nginx"
 NGINX="/usr/sbin/nginx"
 PID="/var/run/nginx.pid"
 SSL="/boot/config/ssl"

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -24,12 +24,8 @@ IDENT="/boot/config/ident.cfg"
 SERVERS="/etc/nginx/conf.d/servers.conf"
 LOCATIONS="/etc/nginx/conf.d/locations.conf"
 NEW="/var/local/emhttp/nginx.ini.new"
-WIREGUARD="/etc/wireguard"
 CERTPATH="$SSL/certs/certificate_bundle.pem"
 MYSERVERS="/boot/config/plugins/dynamix.my.servers/myservers.cfg"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # hold server names
 SERVER_NAMES=()

--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -4,7 +4,7 @@
 # limetech - modified to initialize ntp.conf file from config
 # bergware - added interface bind functionality
 
-SCRIPT="ntpd"
+CALLER="ntpd"
 NTPD="/usr/sbin/ntpd"
 OPTIONS="-g -u ntp:ntp"
 CONF="/etc/ntp.conf"

--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -9,10 +9,6 @@ NTPD="/usr/sbin/ntpd"
 OPTIONS="-g -u ntp:ntp"
 CONF="/etc/ntp.conf"
 IDENT="/boot/config/ident.cfg"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -4,6 +4,7 @@
 # limetech - modified to initialize ntp.conf file from config
 # bergware - added interface bind functionality
 
+SCRIPT="ntpd"
 NTPD="/usr/sbin/ntpd"
 OPTIONS="-g -u ntp:ntp"
 CONF="/etc/ntp.conf"
@@ -13,123 +14,8 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no;
-  if [[ -f $NETWORK_INI ]]; then
-    # get interface and vlan configurations
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      if [[ -e $SYSTEM/$eth ]]; then
-        # main interface
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-        # vlan interface
-        if [[ $(link TYPE) == trunk ]]; then
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-    done
-    # add loopback interface
-    [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
-    [[ $ipv6 == yes ]] && bind+=(::1)
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string
-    bind=${bind[@]}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 build_ntp() {
   cp $CONF- $CONF
@@ -159,12 +45,8 @@ ntpd_start() {
     echo "ntpd already running, not starting again"
     return
   fi
-  # if our config file not present, don't start ntp
-  if [[ ! -f $IDENT ]]; then
-    echo "Missing file: $IDENT"
-    return
-  fi
-  source <(/usr/bin/fromdos <$IDENT)
+  # read Unraid settings
+  [[ -r $IDENT ]] && . <(/usr/bin/fromdos <$IDENT)
   # if ntp not enabled, don't start ntp
   if [[ $USE_NTP != yes ]]; then
     echo "NTP not enabled"
@@ -209,7 +91,7 @@ ntpd_status() {
 
 ntpd_reload() {
   killall -HUP -q ntpd
-  source <(/usr/bin/fromdos <$IDENT)
+  . <(/usr/bin/fromdos <$IDENT)
   build_ntp
   $NTPD $OPTIONS 2>/dev/null
 }

--- a/etc/rc.d/rc.ntpd
+++ b/etc/rc.d/rc.ntpd
@@ -4,7 +4,7 @@
 # limetech - modified to initialize ntp.conf file from config
 # bergware - added interface bind functionality
 
-CALLER="ntpd"
+CALLER="ntp"
 NTPD="/usr/sbin/ntpd"
 OPTIONS="-g -u ntp:ntp"
 CONF="/etc/ntp.conf"

--- a/etc/rc.d/rc.php-fpm
+++ b/etc/rc.d/rc.php-fpm
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 ### BEGIN INIT INFO
 # Provides:          php-fpm

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -12,7 +12,7 @@
 # limetech - get rid of chatty '-l' rpcbind option
 # bergware - added interface bind functionality
 
-SCRIPT="rpc"
+CALLER="rpc"
 RPCBIND="/sbin/rpcbind"
 RPC="/etc/default/rpc"
 

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -12,6 +12,7 @@
 # limetech - get rid of chatty '-l' rpcbind option
 # bergware - added interface bind functionality
 
+SCRIPT="rpc"
 RPCBIND="/sbin/rpcbind"
 RPC="/etc/default/rpc"
 WIREGUARD="/etc/wireguard"
@@ -19,123 +20,8 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Pom1 "^RPCBIND_OPTS=\"\K[^\"]+" $RPC
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=();
-  if [[ -f $NETWORK_INI ]]; then
-    # add interfaces and vlans
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      if [[ -e $SYSTEM/$eth ]]; then
-        # main interface
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-    done
-    # add loopback interface
-    [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
-    [[ $ipv6 == yes ]] && bind+=(::1)
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string
-    bind=${bind[@]}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 # get bind addresses
 if check && [[ -n $bind ]]; then

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -15,10 +15,6 @@
 SCRIPT="rpc"
 RPCBIND="/sbin/rpcbind"
 RPC="/etc/default/rpc"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -14,6 +14,7 @@
 
 CALLER="rpc"
 RPCBIND="/sbin/rpcbind"
+STATD="/sbin/rpc.statd"
 RPC="/etc/default/rpc"
 
 # library functions
@@ -31,7 +32,7 @@ sed -ri "s/^#?(RPCBIND_OPTS)=.*/\1=\"$RPCBIND_OPTS\"/" $RPC 2>/dev/null
 [[ -r $RPC ]] && . $RPC
 
 rpc_start() {
-  if [[ -x $RPCBIND && -x /sbin/rpc.statd ]]; then
+  if [[ -x $RPCBIND && -x $STATD ]]; then
     # Set up port for lockd:
     if [[ -n $LOCKD_TCP_PORT ]]; then
       /sbin/sysctl -w "fs.nfs.nlm_tcpport=$LOCKD_TCP_PORT" 2>/dev/null
@@ -47,15 +48,15 @@ rpc_start() {
       [[ -n $RPC_STATD_HOSTNAME ]] && RPC_STATD_OPTS="$RPC_STATD_OPTS -n $RPC_STATD_HOSTNAME"
       [[ -n $RPC_STATD_PORT ]] && RPC_STATD_OPTS="$RPC_STATD_OPTS -p $RPC_STATD_PORT"
       [[ -n $RPC_STATD_OUTGOING_PORT ]] && RPC_STATD_OPTS="$RPC_STATD_OPTS -o $RPC_STATD_OUTGOING_PORT"
-      echo "Starting RPC NSM (Network Status Monitor):  /sbin/rpc.statd $RPC_STATD_OPTS"
-      /sbin/rpc.statd $RPC_STATD_OPTS 2>/dev/null
+      echo "Starting RPC NSM (Network Status Monitor):  $STATD $RPC_STATD_OPTS"
+      $STATD $RPC_STATD_OPTS 2>/dev/null
     fi
   else
     echo "WARNING:  Cannot start RPC daemons needed for NFS.  One or more of"
     echo "          these required daemons is not executable or is not present"
     echo "          on your system:"
     echo
-    echo "          $RPCBIND or /sbin/rpc.statd"
+    echo "          $RPCBIND or $STATD"
     echo
   fi
 }

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -20,10 +20,6 @@ CONF="/etc/samba/smb-names.conf"
 IDENT="/boot/config/ident.cfg"
 BOOT="/boot/config"
 PRIVATE="/var/lib/samba/private"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -10,12 +10,14 @@
 # limetech - modified to initialize smb-names.conf file from config
 # bergware - added interface bind functionality
 
+SCRIPT="samba"
 SMBD="/usr/sbin/smbd"
 NMBD="/usr/sbin/nmbd"
 WINBINDD="/usr/sbin/winbindd"
 WSDD2="/usr/sbin/wsdd2"
 SMBCONF="/etc/samba/smb.conf"
 CONF="/etc/samba/smb-names.conf"
+IDENT="/boot/config/ident.cfg"
 BOOT="/boot/config"
 PRIVATE="/var/lib/samba/private"
 WIREGUARD="/etc/wireguard"
@@ -23,129 +25,15 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Pom1 "^$1 = \K.*" $CONF
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no;
-  if [[ -f $NETWORK_INI ]]; then
-    # get interface and vlan configurations
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      # main interface
-      if [[ -e $SYSTEM/$eth ]]; then
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) && $USE_NETBIOS == no ]] && ipv6=yes bind+=($net6)
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) && $USE_NETBIOS == no ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) && $USE_NETBIOS == no ]] && ipv6=yes bind+=($net6)
-    done
-    # add loopback interface
-    [[ $ipv4 == yes ]] && bind+=(127.0.0.1)
-    [[ $ipv6 == yes && $USE_NETBIOS == no ]] && bind+=(::1)
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # convert array to string
-    bind=${bind[@]}
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
-}
+# read Unraid settings
+[[ -r $IDENT ]] && . <(/usr/bin/fromdos <$IDENT)
+# disable ipv6 when netbios is used
+[[ $USE_NETBIOS == yes ]] && deny6=1
 
 samba_settings() {
-  # read Unraid settings
-  if [[ -e $BOOT/ident.cfg ]]; then
-    source <(/usr/bin/fromdos < $BOOT/ident.cfg)
-  fi
   [[ -z $COMMENT ]] && COMMENT=""
   [[ -z $SECURITY ]] && SECURITY="user"
   [[ -z $WORKGROUP ]] && WORKGROUP="WORKGROUP"
@@ -161,7 +49,6 @@ samba_settings() {
   echo "hide dot files = $hideDotFiles" >>$CONF
   echo "server multi channel support = $serverMultiChannel" >>$CONF
   echo "max open files = $(ulimit -n)" >>$CONF
-
   # fixme: samba can now auto-register with avahi but conflicts with emhttp, so disable for now
   echo "multicast dns register = No" >>$CONF
 
@@ -178,7 +65,6 @@ samba_settings() {
     echo "disable netbios = yes" >>$CONF
     echo "server min protocol = SMB2" >>$CONF
   fi
-
   if [[ $SECURITY == ads ]]; then
     echo "security = ADS" >>$CONF
     if [[ -z $DOMAIN_SHORT ]]; then
@@ -210,7 +96,6 @@ samba_settings() {
     echo "create mask = 0777" >>$CONF
     echo "directory mask = 0777" >>$CONF
   fi
-
   # bind samba service
   if check; then
     if [[ -n $bind ]]; then
@@ -279,6 +164,7 @@ samba_update() {
     # no action required
     exit 1
   else
+    echo "$(this interfaces) == $bind"
     # service update required
     exit 0
   fi

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -10,7 +10,7 @@
 # limetech - modified to initialize smb-names.conf file from config
 # bergware - added interface bind functionality
 
-CALLER="samba"
+CALLER="smb"
 SMBD="/usr/sbin/smbd"
 NMBD="/usr/sbin/nmbd"
 WINBINDD="/usr/sbin/winbindd"

--- a/etc/rc.d/rc.samba
+++ b/etc/rc.d/rc.samba
@@ -10,7 +10,7 @@
 # limetech - modified to initialize smb-names.conf file from config
 # bergware - added interface bind functionality
 
-SCRIPT="samba"
+CALLER="samba"
 SMBD="/usr/sbin/smbd"
 NMBD="/usr/sbin/nmbd"
 WINBINDD="/usr/sbin/winbindd"

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -2,7 +2,7 @@
 # Start/stop/restart the secure shell server:
 # bergware - added interface bind functionality
 
-CALLER="sshd"
+CALLER="ssh"
 SSHD="/usr/sbin/sshd"
 CONF="/etc/ssh/sshd_config"
 PID="/var/run/sshd.pid"

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -8,10 +8,6 @@ CONF="/etc/ssh/sshd_config"
 PID="/var/run/sshd.pid"
 SSH_BOOT="/boot/config/ssh"
 SSH_ETC="/etc/ssh"
-WIREGUARD="/etc/wireguard"
-NETWORK_INI="/var/local/emhttp/network.ini"
-SYSTEM="/sys/class/net"
-EXTRA="/boot/config/network-extra.cfg"
 
 # library functions
 . /etc/rc.d/rc.library.source

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -2,7 +2,7 @@
 # Start/stop/restart the secure shell server:
 # bergware - added interface bind functionality
 
-SCRIPT="sshd"
+CALLER="sshd"
 SSHD="/usr/sbin/sshd"
 CONF="/etc/ssh/sshd_config"
 PID="/var/run/sshd.pid"
@@ -72,7 +72,7 @@ sshd_reload() {
 
 sshd_update() {
   [[ $(pgrep -cf $SSHD) -eq 0 ]] && exit 1 # not running
-  if check && [[ "$(this ListenAddress)" == "${bind[@]}" && $(this AddressFamily) == $family ]]; then
+  if check && [[ "$(this ListenAddress)" == "${bind[@]}" ]]; then
     # no action required
     exit 1
   else

--- a/etc/rc.d/rc.sshd
+++ b/etc/rc.d/rc.sshd
@@ -2,6 +2,7 @@
 # Start/stop/restart the secure shell server:
 # bergware - added interface bind functionality
 
+SCRIPT="sshd"
 SSHD="/usr/sbin/sshd"
 CONF="/etc/ssh/sshd_config"
 PID="/var/run/sshd.pid"
@@ -12,122 +13,8 @@ NETWORK_INI="/var/local/emhttp/network.ini"
 SYSTEM="/sys/class/net"
 EXTRA="/boot/config/network-extra.cfg"
 
-IPv() {
-  type=${1//[^:]}
-  [[ ${#type} -le ${2:-0} ]] && echo 4 || echo 6
-}
-
-scan() {
-  grep -Pom1 "^$1=\"?\K[^\"]+" $2
-}
-
-link() {
-  grep -Pom1 "^$1=\"\K[^\"]+" $NETWORK_INI.eth
-}
-
-this() {
-  grep -Po "^$1 \K.*" $CONF|tr '\n' ' '|sed 's/ $//'
-}
-
-take() {
-  data=;
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
-  done
-  echo $data
-}
-
-good() {
-  [[ -n $1 && ${1:0:7} != 169.254 && ${1:0:4} != fe80 ]] && echo $1
-}
-
-show() {
-  case $# in
-    1) ip addr show to $1 2>/dev/null|grep -Pom1 '^\d+: \K[^:]+';;
-    2) ip addr show $1 $2 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-    3) ip $1 addr show $2 $3 2>/dev/null|grep -Pom1 'inet6? \K[^\/]+';;
-  esac
-}
-
-remove() {
-  [[ $# -eq 0 ]] && return
-  for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 ]] && unset 'bind[i]'
-  done
-}
-
-extra() {
-  source <(/usr/bin/fromdos <$EXTRA)
-  for net in $include_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      net4=$(show -4 dev $net)
-      net6=$(show -6 dev $net)
-    else
-      # net is an IP address, validate
-      net4=$(show -4 to $net)
-      net6=$(show -6 to $net)
-    fi
-    [[ -n $net4 && -z $(take $net4) ]] && bind+=($net4)
-    [[ -n $net6 && -z $(take $net6) ]] && bind+=($net6)
-  done
-  for net in $exclude_interfaces; do
-    if [[ -z ${net//[^.:]} || ${net//[^.:]} == . ]]; then
-      # net is an interface name, get IP addresses
-      remove $(show -4 dev $net)
-      remove $(show -6 dev $net)
-    else
-      # net is an IP address
-      remove $(show to $net)
-    fi
-  done
-}
-
-check() {
-  # quick check
-  [[ -n $bind ]] && return 0;
-  # preset return values
-  reply=1; bind=(); ipv4=no; ipv6=no; family=any;
-  if [[ -f $NETWORK_INI ]]; then
-    # get interface and vlan configurations
-    for eth in $(grep -Po '^\[\K[^\]]+' $NETWORK_INI); do
-      if [[ -e $SYSTEM/$eth ]]; then
-        # main interface
-        sed -n "/^\[$eth\]/,/^\[eth/p" $NETWORK_INI >$NETWORK_INI.eth
-        net4=$(link IPADDR:0)
-        net6=$(link IPADDR6:0)
-        [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-        [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-        if [[ $(link TYPE) == trunk ]]; then
-          # vlan interface
-          for vlan in $(grep -Po '^VLANID:\K\d+' $NETWORK_INI.eth); do
-            net4=$(link IPADDR:$vlan)
-            net6=$(link IPADDR6:$vlan)
-            [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-            [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-          done
-        fi
-      fi
-    done
-    # add active WG tunnels
-    for wg in $(wg show interfaces); do
-      net4=$(show -4 dev $wg)
-      net6=$(show -6 dev $wg)
-      [[ -n $(good $net4) ]] && ipv4=yes bind+=($net4)
-      [[ -n $(good $net6) ]] && ipv6=yes bind+=($net6)
-    done
-    # add user defined interfaces
-    [[ -f $EXTRA ]] && extra
-    # bind stays array
-    bind=(${bind[@]})
-    [[ $ipv4 == yes && $ipv6 == no ]] && family=inet
-    [[ $ipv6 == yes && $ipv4 == no ]] && family=inet6
-    reply=0
-    # remove temporary file
-    rm -f $NETWORK_INI.eth
-  fi
-  return $reply
-}
+# library functions
+. /etc/rc.d/rc.library.source
 
 build_ssh() {
   if check && [[ -n $bind ]]; then
@@ -144,18 +31,14 @@ build_ssh() {
 sshd_start() {
   # make sure ssh dir exists on flash
   mkdir -p $SSH_BOOT
-
   # restore saved keys, config file, etc. (but not subdirs)
   cp $SSH_BOOT/* $SSH_ETC &>/dev/null
   chmod 600 $SSH_ETC/* &>/dev/null
-
   # create host keys if needed and copy any newly generated key(s) back to flash
   ssh-keygen -A
   cp -n $SSH_ETC/ssh_host*_key* $SSH_BOOT/
-
-  # bind ssh service
+  # build configuration
   build_ssh
-
   # start daemon
   $SSHD 2>/dev/null
 }


### PR DESCRIPTION
Library file is imported by each rc script, which has the common functions This makes maintenance easier

@Limetech: need a symlink for /etc/rc.d/rc.library.source -> /usr/local/etc/rc.d/rc.library.source
