### PR TITLE
rc.docker: Fix multiple fixed IPs

### DIFF
--- a/etc/rc.d/rc.docker
+++ b/etc/rc.d/rc.docker
@@ -196,7 +196,7 @@ start_network(){
       THIS_IP=
       while read_dom; do
         [[ $ENTITY == Network ]] && THIS_NETWORK=$CONTENT
-        [[ $ENTITY == MyIP ]] && THIS_IP=${CONTENT// /} && THIS_IP=${THIS_IP//,/;}
+        [[ $ENTITY == MyIP ]] && THIS_IP=${CONTENT// /,} && THIS_IP=$(echo "${THIS_IP}" | tr -s "," ";")
       done <$XMLFILE
       # only restore valid networks
       if [[ -n $THIS_NETWORK ]]; then
@@ -367,7 +367,7 @@ start_network(){
         THIS_TT=${CONNECT#*,}
         THIS_IP=
         for IP in ${THIS_TT//;/ }; do
-          [[ $IP =~ '.' ]] && THIS_IP="$THIS_IP --ip $IP" || THIS_IP="$THIS_IP --ip6 $IP"
+          [[ $IP =~ ':' ]] && THIS_IP="$THIS_IP --ip6 $IP" || THIS_IP="$THIS_IP --ip $IP"
         done
         docker network connect $THIS_IP $NETWORK $THIS_ID >/dev/null
       done


### PR DESCRIPTION
I noticed a bug in the rc.docker script in 6.11.5. 

I'm running my Docker containers in a custom network `br1` with static IPv4 and IPv6 addresses. I have the addresses added in the "Fixed IP address" field. 

That worked just fine when creating a new container and starting it through that view, or when editing a container. However, after disabling and re-enabling Docker, or after rebooting the server, I noticed that my containers didn't autostart and starting them through the GUI also failed. I had to edit them and re-apply the config to make them start. 

Reading through the rc.docker script, I found the bug that causes this: I had the IP addresses (one IPv6, one IPv4) seperated by spaces, not by commas. When creating a container this works just fine, but when the system starts the container after a reboot, the spaces get trimmed, which resulted in my containers having IPs like `fd12:3456:7890::25:510.0.25.5` (IPv6 and IPv4 immediately after another without any seperator), which Docker obviously rejects. Editing the container sets the IPs correctly again and the container starts. 

I noticed that the old code just removes spaces, and replaces commas with a semicolon. Probably in an assumption that a user would add a comma-separated list that may also have spaces for better readability. 

However nowhere in the GUI does it state that the IPs should be comma-seperated, and given that UnRAID does accept space-seperated IPs at container creation (see #468), it should also still accept them after a reboot. So I changed the code that parses these to make it accept spaces as well. 

I also noticed that there's a discrepancy in how IPv6 addresses are detected. When a container is created, it assumes that any IP that has a colon in it is IPv6 (others are IPv4). When a container is auto-booted, it assumes any IP that has a dot in it is IPv4 (others are IPv6). 

Both assumtions are wrong - `2001:db8::1.2.3.4` has dots but is an IPv6, and `::ffff:1.2.3.4` has colons but is IPv4 (and has to be added with `--ip`, not `-ip6`). 

I didn't find a nice bash-only way to make it detect ::ffff:1.2.3.4 (and also "variants" like 0:0::ffff:1.2.3.4) as IPv4 but not IPv6 addresses like 2001:db8::ffff:1.2.3.4 so I opted to leave it that way, but at least with this change both code paths (container creation and container autoboot) have the same wrong implementation. 

That means if container creation works, container autoboot should also work. Not like before where container creation might work but then container autoboot fails. 

But still, this is another thing that should probably be fixed some time in the future.