### PR TITLE
RC services update

### DIFF
--- a/emhttp/plugins/dynamix/scripts/reload_services
+++ b/emhttp/plugins/dynamix/scripts/reload_services
@@ -1,9 +1,9 @@
 #!/bin/bash
 SERVICES="sshd avahidaemon samba rpc nfsd ntpd nginx"
-job=/tmp/atjob.tmp
 
-[[ -n $1 && -e $job ]] && exit 0
-touch $job
+if [[ -n $1 ]]; then
+  [[ ! -e $1 ]] && touch $1 || exit 0
+fi
 for cmd in $SERVICES; do
   if /etc/rc.d/rc.$cmd update; then
     /etc/rc.d/rc.$cmd reload >/dev/null 2>&1

--- a/etc/rc.d/rc.library.source
+++ b/etc/rc.d/rc.library.source
@@ -49,7 +49,7 @@ scan() {
 good() {
   data=;
   for i in ${!bind[@]}; do
-    [[ ${bind[$i]} == $1 || ${1:0:7} == 169.254 || ${1:0:4} == fe80 ]] && data=$1
+    [[ ${bind[$i]} == $1 || ${1:0:4} == fe80 ]] && data=$1
   done
   echo $data
 }
@@ -57,8 +57,8 @@ good() {
 show() {
   case $# in
     1) ip -br addr show to $1 2>/dev/null|awk '{print $1;exit}';;
-    2) ip -br addr show $1 $2 2>/dev/null|awk '$3 !~ "^169.254" && $3 !~ "^fe80" {print $3;exit}';;
-    3) ip -br $1 addr show $2 $3 2>/dev/null|awk '$3 !~ "^169.254" && $3 !~ "^fe80" {print $3;exit}';;
+    2) ip -br addr show $1 $2 2>/dev/null|awk '$3 !~ "^fe80" {print $3;exit}';;
+    3) ip -br $1 addr show $2 $3 2>/dev/null|awk '$3 !~ "^fe80" {print $3;exit}';;
   esac
 }
 
@@ -147,7 +147,7 @@ check() {
       [[ $CALLER == ntp ]] && name=$(show ${net[1]}) || name=
       [[ ${name:0:2} != wg && -n ${net[1]} ]] && ipv4=yes bind+=($(sub ${net[1]}))
     fi
-  done <<< $(ip -br -4 addr|awk '/^(br|bond|eth|wg)[0-9]+(\.[0-9]+)?/ && $3 !~ "^169.254" {print $1,$3}')
+  done <<< $(ip -br -4 addr|awk '/^(br|bond|eth|wg)[0-9]+(\.[0-9]+)?/ {print $1,$3}')
   # active ipv6 interfaces (including wireguard)
   while IFS='\n' read -r net; do
     net=($net)

--- a/etc/rc.d/rc.nfsd
+++ b/etc/rc.d/rc.nfsd
@@ -99,13 +99,8 @@ nfsd_restart() {
 }
 
 nfsd_reload() {
-  killall -9 nfsd 2>/dev/null
-  sleep 1
-  [[ -z $RPC_NFSD_COUNT ]] && RPC_NFSD_COUNT=8
-  # update default settings
-  sed -ri "s/^(RPC_NFSD_OPTS)=.*/\1=\"$RPC_NFSD_OPTS\"/" $NFS 2>/dev/null
-  [[ -r $NFS ]] && . $NFS
-  $NFSD $RPC_NFSD_OPTS $RPC_NFSD_COUNT 2>/dev/null
+  # restart without info
+  nfsd_restart 1>/dev/null 2>&1
 }
 
 nfsd_update() {

--- a/etc/rc.d/rc.nginx
+++ b/etc/rc.d/rc.nginx
@@ -103,7 +103,7 @@ redirect() {
         if [[ -n $host ]]; then
           echo "server {"
           echo "${t}listen $host:$*; # $(show $addr)"
-          echo "${t}return 302 https://$(fqdn $addr):$PORTSSL\$request_uri;"
+          echo "${t}return 302 https://$(fqdn $addr)$PORTSSL_URL\$request_uri;"
           echo "}"
         fi
       done

--- a/etc/rc.d/rc.rpc
+++ b/etc/rc.d/rc.rpc
@@ -75,12 +75,8 @@ rpc_restart() {
 }
 
 rpc_reload() {
-  killall -9 rpcbind 2>/dev/null
-  sleep 1
-  # update default settings
-  sed -ri "s/^#?(RPCBIND_OPTS)=.*/\1=\"$RPCBIND_OPTS\"/" $RPC 2>/dev/null
-  [[ -r $RPC ]] && . $RPC
-  $RPCBIND -w $RPCBIND_OPTS 2>/dev/null
+  # restart without info
+  rpc_restart 1>/dev/null 2>&1
 }
 
 rpc_update() {

--- a/sbin/create_network_ini
+++ b/sbin/create_network_ini
@@ -223,7 +223,7 @@ done
 
 # delayed execution
 rm -f $job
-echo "sleep 35;$reload job"|at -M now 2>/dev/null
+echo "sleep 35;$reload $job"|at -M now 2>/dev/null
 
 # send update information
 if [[ -n $interface && -n $data && -e /var/run/nginx.socket ]]; then


### PR DESCRIPTION
1. NFS - fix service reload
2. RPC - fix service reload
3. NGINX - remove HTTPS port in FQDN redirect when default 443
4. All services - register IPv4 Link local assignment (169.254.xxx.xxx)
5. All services - make lock file programmable